### PR TITLE
vcsim: init of vspehre provider tests

### DIFF
--- a/.github/workflows/run_forklift_build_on_kind.yml
+++ b/.github/workflows/run_forklift_build_on_kind.yml
@@ -45,6 +45,8 @@ jobs:
       
       - run: kubectl get pods -n konveyor-forklift
 
+      - run: kubectl get providers -n konveyor-forklift
+
       - run: echo "CLUSTER=`kind get kubeconfig | grep server | cut -d ' ' -f6`" >> $GITHUB_ENV
       - run: echo "TOKEN=`kubectl get secrets -n kube-system -o jsonpath='{.items[0].data.token-id}' | base64 -d`.`kubectl get secrets -n kube-system -o jsonpath='{.items[0].data.token-secret}' | base64 -d`" >> $GITHUB_ENV 
 

--- a/build_and_setup_everything_bazel.sh
+++ b/build_and_setup_everything_bazel.sh
@@ -6,6 +6,8 @@
 
 ./deploy_local_forklift_bazel.sh
 
+./vmware/setup.sh
+
 ./k8s-deploy-kubevirt.sh
 
 . ./grant_permissions.sh

--- a/build_and_setup_everything_bazel_manually.sh
+++ b/build_and_setup_everything_bazel_manually.sh
@@ -6,6 +6,8 @@
 
 ./build_forklift_bazel.sh
 
+./vmware/setup.sh
+
 ./deploy_local_forklift_bazel.sh
 
 ./k8s-deploy-kubevirt.sh

--- a/vmware/setup.sh
+++ b/vmware/setup.sh
@@ -1,0 +1,6 @@
+kubectl apply -f ./vmware/vcsim_deployment.yml
+
+while ! kubectl get deployment -n konveyor-forklift vcsim; do sleep 5; done
+kubectl wait deployment -n konveyor-forklift vcsim --for condition=Available=True --timeout=180s
+
+kubectl apply -f ./vmware/vsphere_provider.yml

--- a/vmware/vcsim_deployment.yml
+++ b/vmware/vcsim_deployment.yml
@@ -1,0 +1,35 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vcsim
+  namespace: konveyor-forklift
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vcsim
+  template:
+    metadata:
+      labels:
+        app: vcsim
+    spec:
+      containers:
+      - name: vcsim
+        image: docker.io/vmware/vcsim:latest
+        ports:
+        - containerPort: 8989
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vcsim
+  namespace: konveyor-forklift
+spec:
+  selector:
+    app: vcsim
+  type: ClusterIP
+  ports:
+  - name: vcsim
+    port: 8989
+    targetPort: 8989

--- a/vmware/vsphere_provider.yml
+++ b/vmware/vsphere_provider.yml
@@ -1,0 +1,29 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: vsphere-provider-secret
+  namespace: konveyor-forklift
+  labels:
+    createdForResource: vsphere-provider
+    createdForResourceType: providers
+data:
+  password: MTIzNDU2Cg==
+  thumbprint: >-
+    MkM6MTE6RUQ6RDc6MTM6ODc6N0Q6QjU6NzQ6MTg6Qjg6MUM6NDI6QzI6NTY6MUY6MEQ6Qjk6NUI6Qjk=
+  user: YWRtaW5pc3RyYXRvckB2c3BoZXJlLmxvY2Fs
+type: Opaque
+---
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Provider
+metadata:
+  name: vsphere-provider
+  namespace: konveyor-forklift
+spec:
+  secret:
+    name: vsphere-provider-secret
+    namespace: konveyor-forklift
+  settings:
+    vddkInitImage: 'quay.io/lrotenbe/vddk:7.0.3'
+  type: vsphere
+  url: 'https://vcsim:8989/sdk'


### PR DESCRIPTION
Adding the vcsim for mocking the vsphere provider API. 
The patch does:
- setup of the vcsim deployment in the cluster
- setup k8s service so the controller can access the pod
- add the mocked provider to forklift

The vcsim is also used in the kubevirt CDI for testing the disk migration intself.