### PR TITLE
Add ovirt init of fakeovirt with stubs

### DIFF
--- a/.github/workflows/run_forklift_build_on_kind.yml
+++ b/.github/workflows/run_forklift_build_on_kind.yml
@@ -42,8 +42,10 @@ jobs:
       - run: kubectl version
 
       - run: kubectl wait deployment -n konveyor-forklift forklift-controller --for condition=Available=True --timeout=180s
-      
+
       - run: kubectl get pods -n konveyor-forklift
+
+      - run: kubectl get providers -n konveyor-forklift
 
       - run: echo "CLUSTER=`kind get kubeconfig | grep server | cut -d ' ' -f6`" >> $GITHUB_ENV
       - run: echo "TOKEN=`kubectl get secrets -n kube-system -o jsonpath='{.items[0].data.token-id}' | base64 -d`.`kubectl get secrets -n kube-system -o jsonpath='{.items[0].data.token-secret}' | base64 -d`" >> $GITHUB_ENV 

--- a/build_and_setup_everything_bazel.sh
+++ b/build_and_setup_everything_bazel.sh
@@ -6,6 +6,8 @@
 
 ./deploy_local_forklift_bazel.sh
 
+./ovirt/setup.sh
+
 ./k8s-deploy-kubevirt.sh
 
 . ./grant_permissions.sh

--- a/build_and_setup_everything_bazel_manually.sh
+++ b/build_and_setup_everything_bazel_manually.sh
@@ -8,6 +8,8 @@
 
 ./deploy_local_forklift_bazel.sh
 
+./ovirt/setup.sh
+
 ./k8s-deploy-kubevirt.sh
 
 . ./grant_permissions.sh

--- a/ovirt/Dockerfile
+++ b/ovirt/Dockerfile
@@ -1,0 +1,5 @@
+FROM quay.io/mnecas0/fakeovirt:latest
+
+WORKDIR /app
+
+COPY stubs stubs

--- a/ovirt/fakeovirt_deployment.yml
+++ b/ovirt/fakeovirt_deployment.yml
@@ -1,0 +1,40 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fakeovirt
+  namespace: konveyor-forklift
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fakeovirt
+  template:
+    metadata:
+      labels:
+        app: fakeovirt
+    spec:
+      containers:
+      - name: fakeovirt
+        image: localhost:5001/fakeovirt:latest
+        ports:
+        - containerPort: 12346
+        env:
+          - name: NAMESPACE
+            value: konveyor-forklift
+          - name: PORT
+            value: "12346"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fakeovirt
+  namespace: konveyor-forklift
+spec:
+  selector:
+    app: fakeovirt
+  type: NodePort
+  ports:
+  - name: fakeovirt
+    port: 12346
+    targetPort: 12346

--- a/ovirt/forklift_provider.yml
+++ b/ovirt/forklift_provider.yml
@@ -1,0 +1,28 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: ovirt-provider-secret
+  namespace: konveyor-forklift
+  labels:
+    createdForResource: ovirt-provider
+    createdForResourceType: providers
+data:
+  # insecureSkipVerify: 1
+  insecureSkipVerify: MQ==
+  password: MTIzNDU2
+  user: YWRtaW5AaW50ZXJuYWw=
+type: Opaque
+
+---
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Provider
+metadata:
+  name: ovirt-provider
+  namespace: konveyor-forklift
+spec:
+  secret:
+    name: ovirt-provider-secret
+    namespace: konveyor-forklift
+  type: ovirt
+  url: https://fakeovirt:12346/ovirt-engine/api

--- a/ovirt/setup.sh
+++ b/ovirt/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+docker build ovirt/ -t localhost:5001/fakeovirt
+docker push localhost:5001/fakeovirt
+
+kubectl apply -f ovirt/fakeovirt_deployment.yml
+while ! kubectl get deployment -n konveyor-forklift fakeovirt; do sleep 10; done
+kubectl wait deployment -n konveyor-forklift fakeovirt --for condition=Available=True --timeout=180s
+
+kubectl apply -f ovirt/forklift_provider.yml

--- a/ovirt/stubs/clusters/content
+++ b/ovirt/stubs/clusters/content
@@ -1,0 +1,265 @@
+{
+  "cluster" : [ {
+    "ballooning_enabled" : "true",
+    "bios_type" : "q35_sea_bios",
+    "cpu" : {
+      "architecture" : "x86_64",
+      "type" : "Intel Westmere Family"
+    },
+    "custom_scheduling_policy_properties" : {
+      "property" : [ {
+        "name" : "HighUtilization",
+        "value" : "80"
+      }, {
+        "name" : "CpuOverCommitDurationMinutes",
+        "value" : "2"
+      } ]
+    },
+    "error_handling" : {
+      "on_error" : "migrate"
+    },
+    "fencing_policy" : {
+      "enabled" : "true",
+      "skip_if_connectivity_broken" : {
+        "enabled" : "false",
+        "threshold" : "50"
+      },
+      "skip_if_gluster_bricks_up" : "false",
+      "skip_if_gluster_quorum_not_met" : "false",
+      "skip_if_sd_active" : {
+        "enabled" : "false"
+      }
+    },
+    "fips_mode" : "disabled",
+    "firewall_type" : "firewalld",
+    "gluster_service" : "false",
+    "ha_reservation" : "false",
+    "ksm" : {
+      "enabled" : "true",
+      "merge_across_nodes" : "true"
+    },
+    "log_max_memory_used_threshold" : "95",
+    "log_max_memory_used_threshold_type" : "percentage",
+    "memory_policy" : {
+      "over_commit" : {
+        "percent" : "100"
+      },
+      "transparent_hugepages" : {
+        "enabled" : "true"
+      }
+    },
+    "migration" : {
+      "auto_converge" : "inherit",
+      "bandwidth" : {
+        "assignment_method" : "auto"
+      },
+      "compressed" : "inherit",
+      "encrypted" : "inherit",
+      "policy" : {
+        "id" : "80554327-0569-496b-bdeb-fcbbf52b827b"
+      }
+    },
+    "required_rng_sources" : {
+      "required_rng_source" : [ "urandom" ]
+    },
+    "switch_type" : "legacy",
+    "threads_as_cores" : "false",
+    "trusted_service" : "false",
+    "tunnel_migration" : "false",
+    "version" : {
+      "major" : "4",
+      "minor" : "6"
+    },
+    "virt_service" : "true",
+    "vnc_encryption" : "false",
+    "mac_pool" : {
+      "href" : "/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e",
+      "id" : "58ca604b-017d-0374-0220-00000000014e"
+    },
+    "scheduling_policy" : {
+      "href" : "/ovirt-engine/api/schedulingpolicies/b4ed2332-a7ac-4d5f-9596-99a439cb2812",
+      "id" : "b4ed2332-a7ac-4d5f-9596-99a439cb2812"
+    },
+    "actions" : {
+      "link" : [ {
+        "href" : "/ovirt-engine/api/clusters/8af41cb8-89e8-11ec-96f7-001a4a013f59/syncallnetworks",
+        "rel" : "syncallnetworks"
+      }, {
+        "href" : "/ovirt-engine/api/clusters/8af41cb8-89e8-11ec-96f7-001a4a013f59/resetemulatedmachine",
+        "rel" : "resetemulatedmachine"
+      }, {
+        "href" : "/ovirt-engine/api/clusters/8af41cb8-89e8-11ec-96f7-001a4a013f59/refreshglusterhealstatus",
+        "rel" : "refreshglusterhealstatus"
+      }, {
+        "href" : "/ovirt-engine/api/clusters/8af41cb8-89e8-11ec-96f7-001a4a013f59/upgrade",
+        "rel" : "upgrade"
+      } ]
+    },
+    "name" : "Default",
+    "description" : "The default server cluster",
+    "comment" : "",
+    "href" : "/ovirt-engine/api/clusters/8af41cb8-89e8-11ec-96f7-001a4a013f59",
+    "id" : "8af41cb8-89e8-11ec-96f7-001a4a013f59",
+    "link" : [ {
+      "href" : "/ovirt-engine/api/clusters/8af41cb8-89e8-11ec-96f7-001a4a013f59/affinitygroups",
+      "rel" : "affinitygroups"
+    }, {
+      "href" : "/ovirt-engine/api/clusters/8af41cb8-89e8-11ec-96f7-001a4a013f59/glusterhooks",
+      "rel" : "glusterhooks"
+    }, {
+      "href" : "/ovirt-engine/api/clusters/8af41cb8-89e8-11ec-96f7-001a4a013f59/glustervolumes",
+      "rel" : "glustervolumes"
+    }, {
+      "href" : "/ovirt-engine/api/clusters/8af41cb8-89e8-11ec-96f7-001a4a013f59/enabledfeatures",
+      "rel" : "enabledfeatures"
+    }, {
+      "href" : "/ovirt-engine/api/clusters/8af41cb8-89e8-11ec-96f7-001a4a013f59/externalnetworkproviders",
+      "rel" : "externalnetworkproviders"
+    }, {
+      "href" : "/ovirt-engine/api/clusters/8af41cb8-89e8-11ec-96f7-001a4a013f59/cpuprofiles",
+      "rel" : "cpuprofiles"
+    }, {
+      "href" : "/ovirt-engine/api/clusters/8af41cb8-89e8-11ec-96f7-001a4a013f59/permissions",
+      "rel" : "permissions"
+    }, {
+      "href" : "/ovirt-engine/api/clusters/8af41cb8-89e8-11ec-96f7-001a4a013f59/networkfilters",
+      "rel" : "networkfilters"
+    }, {
+      "href" : "/ovirt-engine/api/clusters/8af41cb8-89e8-11ec-96f7-001a4a013f59/networks",
+      "rel" : "networks"
+    } ]
+  }, {
+    "ballooning_enabled" : "true",
+    "bios_type" : "q35_sea_bios",
+    "cpu" : {
+      "architecture" : "x86_64",
+      "type" : "Intel Westmere Family"
+    },
+    "custom_scheduling_policy_properties" : {
+      "property" : [ {
+        "name" : "HighUtilization",
+        "value" : "80"
+      }, {
+        "name" : "CpuOverCommitDurationMinutes",
+        "value" : "2"
+      } ]
+    },
+    "error_handling" : {
+      "on_error" : "migrate"
+    },
+    "fencing_policy" : {
+      "enabled" : "true",
+      "skip_if_connectivity_broken" : {
+        "enabled" : "true",
+        "threshold" : "50"
+      },
+      "skip_if_gluster_bricks_up" : "false",
+      "skip_if_gluster_quorum_not_met" : "false",
+      "skip_if_sd_active" : {
+        "enabled" : "true"
+      }
+    },
+    "fips_mode" : "disabled",
+    "firewall_type" : "firewalld",
+    "gluster_service" : "false",
+    "ha_reservation" : "false",
+    "ksm" : {
+      "enabled" : "true",
+      "merge_across_nodes" : "true"
+    },
+    "log_max_memory_used_threshold" : "95",
+    "log_max_memory_used_threshold_type" : "percentage",
+    "memory_policy" : {
+      "over_commit" : {
+        "percent" : "100"
+      },
+      "transparent_hugepages" : {
+        "enabled" : "true"
+      }
+    },
+    "migration" : {
+      "auto_converge" : "inherit",
+      "bandwidth" : {
+        "assignment_method" : "auto"
+      },
+      "compressed" : "inherit",
+      "encrypted" : "inherit",
+      "policy" : {
+        "id" : "80554327-0569-496b-bdeb-fcbbf52b827b"
+      }
+    },
+    "required_rng_sources" : {
+      "required_rng_source" : [ "urandom" ]
+    },
+    "switch_type" : "legacy",
+    "threads_as_cores" : "false",
+    "trusted_service" : "false",
+    "tunnel_migration" : "false",
+    "version" : {
+      "major" : "4",
+      "minor" : "6"
+    },
+    "virt_service" : "true",
+    "vnc_encryption" : "true",
+    "data_center" : {
+      "href" : "/ovirt-engine/api/datacenters/32ebd239-25a2-4a13-b514-5bf7c8de6878",
+      "id" : "32ebd239-25a2-4a13-b514-5bf7c8de6878"
+    },
+    "mac_pool" : {
+      "href" : "/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e",
+      "id" : "58ca604b-017d-0374-0220-00000000014e"
+    },
+    "scheduling_policy" : {
+      "href" : "/ovirt-engine/api/schedulingpolicies/b4ed2332-a7ac-4d5f-9596-99a439cb2812",
+      "id" : "b4ed2332-a7ac-4d5f-9596-99a439cb2812"
+    },
+    "actions" : {
+      "link" : [ {
+        "href" : "/ovirt-engine/api/clusters/b94f0a35-8ed8-429c-999a-4d776640107e/syncallnetworks",
+        "rel" : "syncallnetworks"
+      }, {
+        "href" : "/ovirt-engine/api/clusters/b94f0a35-8ed8-429c-999a-4d776640107e/resetemulatedmachine",
+        "rel" : "resetemulatedmachine"
+      }, {
+        "href" : "/ovirt-engine/api/clusters/b94f0a35-8ed8-429c-999a-4d776640107e/refreshglusterhealstatus",
+        "rel" : "refreshglusterhealstatus"
+      }, {
+        "href" : "/ovirt-engine/api/clusters/b94f0a35-8ed8-429c-999a-4d776640107e/upgrade",
+        "rel" : "upgrade"
+      } ]
+    },
+    "name" : "Test",
+    "description" : "",
+    "comment" : "",
+    "href" : "/ovirt-engine/api/clusters/b94f0a35-8ed8-429c-999a-4d776640107e",
+    "id" : "b94f0a35-8ed8-429c-999a-4d776640107e",
+    "link" : [ {
+      "href" : "/ovirt-engine/api/clusters/b94f0a35-8ed8-429c-999a-4d776640107e/affinitygroups",
+      "rel" : "affinitygroups"
+    }, {
+      "href" : "/ovirt-engine/api/clusters/b94f0a35-8ed8-429c-999a-4d776640107e/glusterhooks",
+      "rel" : "glusterhooks"
+    }, {
+      "href" : "/ovirt-engine/api/clusters/b94f0a35-8ed8-429c-999a-4d776640107e/glustervolumes",
+      "rel" : "glustervolumes"
+    }, {
+      "href" : "/ovirt-engine/api/clusters/b94f0a35-8ed8-429c-999a-4d776640107e/enabledfeatures",
+      "rel" : "enabledfeatures"
+    }, {
+      "href" : "/ovirt-engine/api/clusters/b94f0a35-8ed8-429c-999a-4d776640107e/externalnetworkproviders",
+      "rel" : "externalnetworkproviders"
+    }, {
+      "href" : "/ovirt-engine/api/clusters/b94f0a35-8ed8-429c-999a-4d776640107e/cpuprofiles",
+      "rel" : "cpuprofiles"
+    }, {
+      "href" : "/ovirt-engine/api/clusters/b94f0a35-8ed8-429c-999a-4d776640107e/permissions",
+      "rel" : "permissions"
+    }, {
+      "href" : "/ovirt-engine/api/clusters/b94f0a35-8ed8-429c-999a-4d776640107e/networkfilters",
+      "rel" : "networkfilters"
+    }, {
+      "href" : "/ovirt-engine/api/clusters/b94f0a35-8ed8-429c-999a-4d776640107e/networks",
+      "rel" : "networks"
+    } ]
+  } ]
+}

--- a/ovirt/stubs/content
+++ b/ovirt/stubs/content
@@ -1,0 +1,207 @@
+{
+  "product_info" : {
+    "instance_id" : "8e221fd4-89e8-11ec-8f7c-001a4a013f59",
+    "name" : "oVirt Engine",
+    "version" : {
+      "build" : "10",
+      "full_version" : "4.4.10.6-1.el8",
+      "major" : "4",
+      "minor" : "4",
+      "revision" : "0"
+    }
+  },
+  "special_objects" : {
+    "blank_template" : {
+      "href" : "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000",
+      "id" : "00000000-0000-0000-0000-000000000000"
+    },
+    "root_tag" : {
+      "href" : "/ovirt-engine/api/tags/00000000-0000-0000-0000-000000000000",
+      "id" : "00000000-0000-0000-0000-000000000000"
+    }
+  },
+  "summary" : {
+    "hosts" : {
+      "active" : "1",
+      "total" : "1"
+    },
+    "storage_domains" : {
+      "active" : "1",
+      "total" : "2"
+    },
+    "users" : {
+      "active" : "1",
+      "total" : "1"
+    },
+    "vms" : {
+      "active" : "1",
+      "total" : "2"
+    }
+  },
+  "time" : 1666082820388,
+  "authenticated_user" : {
+    "href" : "/ovirt-engine/api/users/bfd9c4d2-89e8-11ec-8d18-001a4a013f59",
+    "id" : "bfd9c4d2-89e8-11ec-8d18-001a4a013f59"
+  },
+  "effective_user" : {
+    "href" : "/ovirt-engine/api/users/bfd9c4d2-89e8-11ec-8d18-001a4a013f59",
+    "id" : "bfd9c4d2-89e8-11ec-8d18-001a4a013f59"
+  },
+  "link" : [ {
+    "href" : "/ovirt-engine/api/clusters",
+    "rel" : "clusters"
+  }, {
+    "href" : "/ovirt-engine/api/clusters?search={query}",
+    "rel" : "clusters/search"
+  }, {
+    "href" : "/ovirt-engine/api/datacenters",
+    "rel" : "datacenters"
+  }, {
+    "href" : "/ovirt-engine/api/datacenters?search={query}",
+    "rel" : "datacenters/search"
+  }, {
+    "href" : "/ovirt-engine/api/events",
+    "rel" : "events"
+  }, {
+    "href" : "/ovirt-engine/api/events;from={event_id}?search={query}",
+    "rel" : "events/search"
+  }, {
+    "href" : "/ovirt-engine/api/hosts",
+    "rel" : "hosts"
+  }, {
+    "href" : "/ovirt-engine/api/hosts?search={query}",
+    "rel" : "hosts/search"
+  }, {
+    "href" : "/ovirt-engine/api/networks",
+    "rel" : "networks"
+  }, {
+    "href" : "/ovirt-engine/api/networks?search={query}",
+    "rel" : "networks/search"
+  }, {
+    "href" : "/ovirt-engine/api/roles",
+    "rel" : "roles"
+  }, {
+    "href" : "/ovirt-engine/api/storagedomains",
+    "rel" : "storagedomains"
+  }, {
+    "href" : "/ovirt-engine/api/storagedomains?search={query}",
+    "rel" : "storagedomains/search"
+  }, {
+    "href" : "/ovirt-engine/api/tags",
+    "rel" : "tags"
+  }, {
+    "href" : "/ovirt-engine/api/bookmarks",
+    "rel" : "bookmarks"
+  }, {
+    "href" : "/ovirt-engine/api/icons",
+    "rel" : "icons"
+  }, {
+    "href" : "/ovirt-engine/api/templates",
+    "rel" : "templates"
+  }, {
+    "href" : "/ovirt-engine/api/templates?search={query}",
+    "rel" : "templates/search"
+  }, {
+    "href" : "/ovirt-engine/api/instancetypes",
+    "rel" : "instancetypes"
+  }, {
+    "href" : "/ovirt-engine/api/instancetypes?search={query}",
+    "rel" : "instancetypes/search"
+  }, {
+    "href" : "/ovirt-engine/api/users",
+    "rel" : "users"
+  }, {
+    "href" : "/ovirt-engine/api/users?search={query}",
+    "rel" : "users/search"
+  }, {
+    "href" : "/ovirt-engine/api/groups",
+    "rel" : "groups"
+  }, {
+    "href" : "/ovirt-engine/api/groups?search={query}",
+    "rel" : "groups/search"
+  }, {
+    "href" : "/ovirt-engine/api/domains",
+    "rel" : "domains"
+  }, {
+    "href" : "/ovirt-engine/api/vmpools",
+    "rel" : "vmpools"
+  }, {
+    "href" : "/ovirt-engine/api/vmpools?search={query}",
+    "rel" : "vmpools/search"
+  }, {
+    "href" : "/ovirt-engine/api/vms",
+    "rel" : "vms"
+  }, {
+    "href" : "/ovirt-engine/api/vms?search={query}",
+    "rel" : "vms/search"
+  }, {
+    "href" : "/ovirt-engine/api/disks",
+    "rel" : "disks"
+  }, {
+    "href" : "/ovirt-engine/api/disks?search={query}",
+    "rel" : "disks/search"
+  }, {
+    "href" : "/ovirt-engine/api/jobs",
+    "rel" : "jobs"
+  }, {
+    "href" : "/ovirt-engine/api/storageconnections",
+    "rel" : "storageconnections"
+  }, {
+    "href" : "/ovirt-engine/api/vnicprofiles",
+    "rel" : "vnicprofiles"
+  }, {
+    "href" : "/ovirt-engine/api/diskprofiles",
+    "rel" : "diskprofiles"
+  }, {
+    "href" : "/ovirt-engine/api/cpuprofiles",
+    "rel" : "cpuprofiles"
+  }, {
+    "href" : "/ovirt-engine/api/schedulingpolicyunits",
+    "rel" : "schedulingpolicyunits"
+  }, {
+    "href" : "/ovirt-engine/api/schedulingpolicies",
+    "rel" : "schedulingpolicies"
+  }, {
+    "href" : "/ovirt-engine/api/permissions",
+    "rel" : "permissions"
+  }, {
+    "href" : "/ovirt-engine/api/macpools",
+    "rel" : "macpools"
+  }, {
+    "href" : "/ovirt-engine/api/networkfilters",
+    "rel" : "networkfilters"
+  }, {
+    "href" : "/ovirt-engine/api/operatingsystems",
+    "rel" : "operatingsystems"
+  }, {
+    "href" : "/ovirt-engine/api/externalhostproviders",
+    "rel" : "externalhostproviders"
+  }, {
+    "href" : "/ovirt-engine/api/openstackimageproviders",
+    "rel" : "openstackimageproviders"
+  }, {
+    "href" : "/ovirt-engine/api/openstackvolumeproviders",
+    "rel" : "openstackvolumeproviders"
+  }, {
+    "href" : "/ovirt-engine/api/openstacknetworkproviders",
+    "rel" : "openstacknetworkproviders"
+  }, {
+    "href" : "/ovirt-engine/api/katelloerrata",
+    "rel" : "katelloerrata"
+  }, {
+    "href" : "/ovirt-engine/api/affinitylabels",
+    "rel" : "affinitylabels"
+  }, {
+    "href" : "/ovirt-engine/api/clusterlevels",
+    "rel" : "clusterlevels"
+  }, {
+    "href" : "/ovirt-engine/api/imagetransfers",
+    "rel" : "imagetransfers"
+  }, {
+    "href" : "/ovirt-engine/api/externalvmimports",
+    "rel" : "externalvmimports"
+  }, {
+    "href" : "/ovirt-engine/api/externaltemplateimports",
+    "rel" : "externaltemplateimports"
+  } ]
+}

--- a/ovirt/stubs/datacenters/content
+++ b/ovirt/stubs/datacenters/content
@@ -1,0 +1,56 @@
+{
+  "data_center" : [ {
+    "local" : "false",
+    "quota_mode" : "disabled",
+    "status" : "up",
+    "storage_format" : "v5",
+    "supported_versions" : {
+      "version" : [ {
+        "major" : "4",
+        "minor" : "6"
+      } ]
+    },
+    "version" : {
+      "major" : "4",
+      "minor" : "6"
+    },
+    "mac_pool" : {
+      "href" : "/ovirt-engine/api/macpools/58ca604b-017d-0374-0220-00000000014e",
+      "id" : "58ca604b-017d-0374-0220-00000000014e"
+    },
+    "actions" : {
+      "link" : [ {
+        "href" : "/ovirt-engine/api/datacenters/32ebd239-25a2-4a13-b514-5bf7c8de6878/setmaster",
+        "rel" : "setmaster"
+      }, {
+        "href" : "/ovirt-engine/api/datacenters/32ebd239-25a2-4a13-b514-5bf7c8de6878/cleanfinishedtasks",
+        "rel" : "cleanfinishedtasks"
+      } ]
+    },
+    "name" : "Default",
+    "href" : "/ovirt-engine/api/datacenters/32ebd239-25a2-4a13-b514-5bf7c8de6878",
+    "id" : "32ebd239-25a2-4a13-b514-5bf7c8de6878",
+    "link" : [ {
+      "href" : "/ovirt-engine/api/datacenters/32ebd239-25a2-4a13-b514-5bf7c8de6878/clusters",
+      "rel" : "clusters"
+    }, {
+      "href" : "/ovirt-engine/api/datacenters/32ebd239-25a2-4a13-b514-5bf7c8de6878/quotas",
+      "rel" : "quotas"
+    }, {
+      "href" : "/ovirt-engine/api/datacenters/32ebd239-25a2-4a13-b514-5bf7c8de6878/qoss",
+      "rel" : "qoss"
+    }, {
+      "href" : "/ovirt-engine/api/datacenters/32ebd239-25a2-4a13-b514-5bf7c8de6878/iscsibonds",
+      "rel" : "iscsibonds"
+    }, {
+      "href" : "/ovirt-engine/api/datacenters/32ebd239-25a2-4a13-b514-5bf7c8de6878/permissions",
+      "rel" : "permissions"
+    }, {
+      "href" : "/ovirt-engine/api/datacenters/32ebd239-25a2-4a13-b514-5bf7c8de6878/networks",
+      "rel" : "networks"
+    }, {
+      "href" : "/ovirt-engine/api/datacenters/32ebd239-25a2-4a13-b514-5bf7c8de6878/storagedomains",
+      "rel" : "storagedomains"
+    } ]
+  } ]
+}

--- a/ovirt/stubs/diskprofiles/content
+++ b/ovirt/stubs/diskprofiles/content
@@ -1,0 +1,15 @@
+{
+  "disk_profile" : [ {
+    "storage_domain" : {
+      "href" : "/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8",
+      "id" : "95ef6fee-5773-46a2-9340-a636958a96b8"
+    },
+    "name" : "test",
+    "href" : "/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8/diskprofiles/0f9c5266-0192-4127-897f-b297cf6c8e04",
+    "id" : "0f9c5266-0192-4127-897f-b297cf6c8e04",
+    "link" : [ {
+      "href" : "/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8/diskprofiles/0f9c5266-0192-4127-897f-b297cf6c8e04/permissions",
+      "rel" : "permissions"
+    } ]
+  } ]
+}

--- a/ovirt/stubs/disks/content
+++ b/ovirt/stubs/disks/content
@@ -1,0 +1,514 @@
+{
+  "disk" : [ {
+    "actual_size" : "4096",
+    "alias" : "OVF_STORE",
+    "backup" : "none",
+    "content_type" : "ovf_store",
+    "format" : "raw",
+    "image_id" : "a6acacea-bfeb-4b85-8acb-aa8b97eb2ad3",
+    "propagate_errors" : "false",
+    "provisioned_size" : "44032",
+    "shareable" : "true",
+    "sparse" : "true",
+    "status" : "ok",
+    "storage_type" : "image",
+    "wipe_after_delete" : "false",
+    "disk_profile" : {
+      "href" : "/ovirt-engine/api/diskprofiles/0f9c5266-0192-4127-897f-b297cf6c8e04",
+      "id" : "0f9c5266-0192-4127-897f-b297cf6c8e04"
+    },
+    "quota" : {
+      "href" : "/ovirt-engine/api/datacenters/32ebd239-25a2-4a13-b514-5bf7c8de6878/quotas/712172d4-dc8e-4989-8a20-578506088116",
+      "id" : "712172d4-dc8e-4989-8a20-578506088116"
+    },
+    "storage_domains" : {
+      "storage_domain" : [ {
+        "href" : "/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8",
+        "id" : "95ef6fee-5773-46a2-9340-a636958a96b8"
+      } ]
+    },
+    "actions" : {
+      "link" : [ {
+        "href" : "/ovirt-engine/api/disks/737b09a5-7f9e-47ec-85f3-b39bc163a530/reduce",
+        "rel" : "reduce"
+      }, {
+        "href" : "/ovirt-engine/api/disks/737b09a5-7f9e-47ec-85f3-b39bc163a530/sparsify",
+        "rel" : "sparsify"
+      }, {
+        "href" : "/ovirt-engine/api/disks/737b09a5-7f9e-47ec-85f3-b39bc163a530/copy",
+        "rel" : "copy"
+      }, {
+        "href" : "/ovirt-engine/api/disks/737b09a5-7f9e-47ec-85f3-b39bc163a530/export",
+        "rel" : "export"
+      }, {
+        "href" : "/ovirt-engine/api/disks/737b09a5-7f9e-47ec-85f3-b39bc163a530/move",
+        "rel" : "move"
+      }, {
+        "href" : "/ovirt-engine/api/disks/737b09a5-7f9e-47ec-85f3-b39bc163a530/refreshlun",
+        "rel" : "refreshlun"
+      } ]
+    },
+    "name" : "OVF_STORE",
+    "description" : "OVF_STORE",
+    "href" : "/ovirt-engine/api/disks/737b09a5-7f9e-47ec-85f3-b39bc163a530",
+    "id" : "737b09a5-7f9e-47ec-85f3-b39bc163a530",
+    "link" : [ {
+      "href" : "/ovirt-engine/api/disks/737b09a5-7f9e-47ec-85f3-b39bc163a530/permissions",
+      "rel" : "permissions"
+    }, {
+      "href" : "/ovirt-engine/api/disks/737b09a5-7f9e-47ec-85f3-b39bc163a530/disksnapshots",
+      "rel" : "disksnapshots"
+    }, {
+      "href" : "/ovirt-engine/api/disks/737b09a5-7f9e-47ec-85f3-b39bc163a530/statistics",
+      "rel" : "statistics"
+    } ]
+  }, {
+    "actual_size" : "4096",
+    "alias" : "OVF_STORE",
+    "backup" : "none",
+    "content_type" : "ovf_store",
+    "format" : "raw",
+    "image_id" : "3d4a12d7-a85a-4d4e-b0e7-7a3202cfc2c2",
+    "propagate_errors" : "false",
+    "provisioned_size" : "44032",
+    "shareable" : "true",
+    "sparse" : "true",
+    "status" : "ok",
+    "storage_type" : "image",
+    "wipe_after_delete" : "false",
+    "disk_profile" : {
+      "href" : "/ovirt-engine/api/diskprofiles/0f9c5266-0192-4127-897f-b297cf6c8e04",
+      "id" : "0f9c5266-0192-4127-897f-b297cf6c8e04"
+    },
+    "quota" : {
+      "href" : "/ovirt-engine/api/datacenters/32ebd239-25a2-4a13-b514-5bf7c8de6878/quotas/712172d4-dc8e-4989-8a20-578506088116",
+      "id" : "712172d4-dc8e-4989-8a20-578506088116"
+    },
+    "storage_domains" : {
+      "storage_domain" : [ {
+        "href" : "/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8",
+        "id" : "95ef6fee-5773-46a2-9340-a636958a96b8"
+      } ]
+    },
+    "actions" : {
+      "link" : [ {
+        "href" : "/ovirt-engine/api/disks/2837e27e-9cd3-4cdb-b2c8-8a7fbd08612a/reduce",
+        "rel" : "reduce"
+      }, {
+        "href" : "/ovirt-engine/api/disks/2837e27e-9cd3-4cdb-b2c8-8a7fbd08612a/sparsify",
+        "rel" : "sparsify"
+      }, {
+        "href" : "/ovirt-engine/api/disks/2837e27e-9cd3-4cdb-b2c8-8a7fbd08612a/copy",
+        "rel" : "copy"
+      }, {
+        "href" : "/ovirt-engine/api/disks/2837e27e-9cd3-4cdb-b2c8-8a7fbd08612a/export",
+        "rel" : "export"
+      }, {
+        "href" : "/ovirt-engine/api/disks/2837e27e-9cd3-4cdb-b2c8-8a7fbd08612a/move",
+        "rel" : "move"
+      }, {
+        "href" : "/ovirt-engine/api/disks/2837e27e-9cd3-4cdb-b2c8-8a7fbd08612a/refreshlun",
+        "rel" : "refreshlun"
+      } ]
+    },
+    "name" : "OVF_STORE",
+    "description" : "OVF_STORE",
+    "href" : "/ovirt-engine/api/disks/2837e27e-9cd3-4cdb-b2c8-8a7fbd08612a",
+    "id" : "2837e27e-9cd3-4cdb-b2c8-8a7fbd08612a",
+    "link" : [ {
+      "href" : "/ovirt-engine/api/disks/2837e27e-9cd3-4cdb-b2c8-8a7fbd08612a/permissions",
+      "rel" : "permissions"
+    }, {
+      "href" : "/ovirt-engine/api/disks/2837e27e-9cd3-4cdb-b2c8-8a7fbd08612a/disksnapshots",
+      "rel" : "disksnapshots"
+    }, {
+      "href" : "/ovirt-engine/api/disks/2837e27e-9cd3-4cdb-b2c8-8a7fbd08612a/statistics",
+      "rel" : "statistics"
+    } ]
+  }, {
+    "actual_size" : "4096",
+    "alias" : "test",
+    "backup" : "none",
+    "content_type" : "data",
+    "format" : "raw",
+    "image_id" : "fda31e9b-580d-4d2f-9650-2171c2a8196e",
+    "propagate_errors" : "false",
+    "provisioned_size" : "1073741824",
+    "shareable" : "false",
+    "sparse" : "true",
+    "status" : "ok",
+    "storage_type" : "image",
+    "total_size" : "4096",
+    "wipe_after_delete" : "false",
+    "disk_profile" : {
+      "href" : "/ovirt-engine/api/diskprofiles/0f9c5266-0192-4127-897f-b297cf6c8e04",
+      "id" : "0f9c5266-0192-4127-897f-b297cf6c8e04"
+    },
+    "quota" : {
+      "href" : "/ovirt-engine/api/datacenters/32ebd239-25a2-4a13-b514-5bf7c8de6878/quotas/712172d4-dc8e-4989-8a20-578506088116",
+      "id" : "712172d4-dc8e-4989-8a20-578506088116"
+    },
+    "storage_domains" : {
+      "storage_domain" : [ {
+        "href" : "/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8",
+        "id" : "95ef6fee-5773-46a2-9340-a636958a96b8"
+      } ]
+    },
+    "actions" : {
+      "link" : [ {
+        "href" : "/ovirt-engine/api/disks/f56564ed-ca74-4d96-9ec6-4b3999a8d93d/reduce",
+        "rel" : "reduce"
+      }, {
+        "href" : "/ovirt-engine/api/disks/f56564ed-ca74-4d96-9ec6-4b3999a8d93d/sparsify",
+        "rel" : "sparsify"
+      }, {
+        "href" : "/ovirt-engine/api/disks/f56564ed-ca74-4d96-9ec6-4b3999a8d93d/copy",
+        "rel" : "copy"
+      }, {
+        "href" : "/ovirt-engine/api/disks/f56564ed-ca74-4d96-9ec6-4b3999a8d93d/export",
+        "rel" : "export"
+      }, {
+        "href" : "/ovirt-engine/api/disks/f56564ed-ca74-4d96-9ec6-4b3999a8d93d/move",
+        "rel" : "move"
+      }, {
+        "href" : "/ovirt-engine/api/disks/f56564ed-ca74-4d96-9ec6-4b3999a8d93d/refreshlun",
+        "rel" : "refreshlun"
+      } ]
+    },
+    "name" : "test",
+    "description" : "",
+    "href" : "/ovirt-engine/api/disks/f56564ed-ca74-4d96-9ec6-4b3999a8d93d",
+    "id" : "f56564ed-ca74-4d96-9ec6-4b3999a8d93d",
+    "link" : [ {
+      "href" : "/ovirt-engine/api/disks/f56564ed-ca74-4d96-9ec6-4b3999a8d93d/permissions",
+      "rel" : "permissions"
+    }, {
+      "href" : "/ovirt-engine/api/disks/f56564ed-ca74-4d96-9ec6-4b3999a8d93d/disksnapshots",
+      "rel" : "disksnapshots"
+    }, {
+      "href" : "/ovirt-engine/api/disks/f56564ed-ca74-4d96-9ec6-4b3999a8d93d/statistics",
+      "rel" : "statistics"
+    } ]
+  }, {
+    "actual_size" : "1020264448",
+    "alias" : "CentOS-7-x86_64-Minimal-2009.iso",
+    "backup" : "none",
+    "content_type" : "iso",
+    "format" : "raw",
+    "image_id" : "6d7f1cae-286b-4727-8661-4c2c33d518ae",
+    "propagate_errors" : "false",
+    "provisioned_size" : "1020264448",
+    "shareable" : "false",
+    "sparse" : "true",
+    "status" : "ok",
+    "storage_type" : "image",
+    "total_size" : "1020264448",
+    "wipe_after_delete" : "false",
+    "disk_profile" : {
+      "href" : "/ovirt-engine/api/diskprofiles/0f9c5266-0192-4127-897f-b297cf6c8e04",
+      "id" : "0f9c5266-0192-4127-897f-b297cf6c8e04"
+    },
+    "quota" : {
+      "href" : "/ovirt-engine/api/datacenters/32ebd239-25a2-4a13-b514-5bf7c8de6878/quotas/712172d4-dc8e-4989-8a20-578506088116",
+      "id" : "712172d4-dc8e-4989-8a20-578506088116"
+    },
+    "storage_domains" : {
+      "storage_domain" : [ {
+        "href" : "/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8",
+        "id" : "95ef6fee-5773-46a2-9340-a636958a96b8"
+      } ]
+    },
+    "actions" : {
+      "link" : [ {
+        "href" : "/ovirt-engine/api/disks/a3baf378-11e7-4df4-b726-d4265cf343f3/reduce",
+        "rel" : "reduce"
+      }, {
+        "href" : "/ovirt-engine/api/disks/a3baf378-11e7-4df4-b726-d4265cf343f3/sparsify",
+        "rel" : "sparsify"
+      }, {
+        "href" : "/ovirt-engine/api/disks/a3baf378-11e7-4df4-b726-d4265cf343f3/copy",
+        "rel" : "copy"
+      }, {
+        "href" : "/ovirt-engine/api/disks/a3baf378-11e7-4df4-b726-d4265cf343f3/export",
+        "rel" : "export"
+      }, {
+        "href" : "/ovirt-engine/api/disks/a3baf378-11e7-4df4-b726-d4265cf343f3/move",
+        "rel" : "move"
+      }, {
+        "href" : "/ovirt-engine/api/disks/a3baf378-11e7-4df4-b726-d4265cf343f3/refreshlun",
+        "rel" : "refreshlun"
+      } ]
+    },
+    "name" : "CentOS-7-x86_64-Minimal-2009.iso",
+    "description" : "CentOS-7-x86_64-Minimal-2009.iso",
+    "href" : "/ovirt-engine/api/disks/a3baf378-11e7-4df4-b726-d4265cf343f3",
+    "id" : "a3baf378-11e7-4df4-b726-d4265cf343f3",
+    "link" : [ {
+      "href" : "/ovirt-engine/api/disks/a3baf378-11e7-4df4-b726-d4265cf343f3/permissions",
+      "rel" : "permissions"
+    }, {
+      "href" : "/ovirt-engine/api/disks/a3baf378-11e7-4df4-b726-d4265cf343f3/disksnapshots",
+      "rel" : "disksnapshots"
+    }, {
+      "href" : "/ovirt-engine/api/disks/a3baf378-11e7-4df4-b726-d4265cf343f3/statistics",
+      "rel" : "statistics"
+    } ]
+  }, {
+    "actual_size" : "200704",
+    "alias" : "myvm_disk",
+    "backup" : "none",
+    "content_type" : "data",
+    "format" : "cow",
+    "image_id" : "8a51580d-07b2-4736-b24d-31f748143921",
+    "propagate_errors" : "false",
+    "provisioned_size" : "10737418240",
+    "qcow_version" : "qcow2_v3",
+    "shareable" : "false",
+    "sparse" : "true",
+    "status" : "ok",
+    "storage_type" : "image",
+    "total_size" : "200704",
+    "wipe_after_delete" : "false",
+    "disk_profile" : {
+      "href" : "/ovirt-engine/api/diskprofiles/0f9c5266-0192-4127-897f-b297cf6c8e04",
+      "id" : "0f9c5266-0192-4127-897f-b297cf6c8e04"
+    },
+    "quota" : {
+      "href" : "/ovirt-engine/api/datacenters/32ebd239-25a2-4a13-b514-5bf7c8de6878/quotas/712172d4-dc8e-4989-8a20-578506088116",
+      "id" : "712172d4-dc8e-4989-8a20-578506088116"
+    },
+    "storage_domains" : {
+      "storage_domain" : [ {
+        "href" : "/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8",
+        "id" : "95ef6fee-5773-46a2-9340-a636958a96b8"
+      } ]
+    },
+    "actions" : {
+      "link" : [ {
+        "href" : "/ovirt-engine/api/disks/ea164502-1efa-4d13-a9bf-4e3d32433949/reduce",
+        "rel" : "reduce"
+      }, {
+        "href" : "/ovirt-engine/api/disks/ea164502-1efa-4d13-a9bf-4e3d32433949/sparsify",
+        "rel" : "sparsify"
+      }, {
+        "href" : "/ovirt-engine/api/disks/ea164502-1efa-4d13-a9bf-4e3d32433949/copy",
+        "rel" : "copy"
+      }, {
+        "href" : "/ovirt-engine/api/disks/ea164502-1efa-4d13-a9bf-4e3d32433949/export",
+        "rel" : "export"
+      }, {
+        "href" : "/ovirt-engine/api/disks/ea164502-1efa-4d13-a9bf-4e3d32433949/move",
+        "rel" : "move"
+      }, {
+        "href" : "/ovirt-engine/api/disks/ea164502-1efa-4d13-a9bf-4e3d32433949/refreshlun",
+        "rel" : "refreshlun"
+      } ]
+    },
+    "name" : "myvm_disk",
+    "description" : "",
+    "href" : "/ovirt-engine/api/disks/ea164502-1efa-4d13-a9bf-4e3d32433949",
+    "id" : "ea164502-1efa-4d13-a9bf-4e3d32433949",
+    "link" : [ {
+      "href" : "/ovirt-engine/api/disks/ea164502-1efa-4d13-a9bf-4e3d32433949/permissions",
+      "rel" : "permissions"
+    }, {
+      "href" : "/ovirt-engine/api/disks/ea164502-1efa-4d13-a9bf-4e3d32433949/disksnapshots",
+      "rel" : "disksnapshots"
+    }, {
+      "href" : "/ovirt-engine/api/disks/ea164502-1efa-4d13-a9bf-4e3d32433949/statistics",
+      "rel" : "statistics"
+    } ]
+  }, {
+    "actual_size" : "4096",
+    "alias" : "test_Disk1",
+    "backup" : "none",
+    "content_type" : "data",
+    "format" : "raw",
+    "image_id" : "83473151-ae7c-492d-b68f-a3e84f7d6c00",
+    "propagate_errors" : "false",
+    "provisioned_size" : "53687091200",
+    "shareable" : "false",
+    "sparse" : "true",
+    "status" : "ok",
+    "storage_type" : "image",
+    "total_size" : "4096",
+    "wipe_after_delete" : "false",
+    "disk_profile" : {
+      "href" : "/ovirt-engine/api/diskprofiles/0f9c5266-0192-4127-897f-b297cf6c8e04",
+      "id" : "0f9c5266-0192-4127-897f-b297cf6c8e04"
+    },
+    "quota" : {
+      "href" : "/ovirt-engine/api/datacenters/32ebd239-25a2-4a13-b514-5bf7c8de6878/quotas/712172d4-dc8e-4989-8a20-578506088116",
+      "id" : "712172d4-dc8e-4989-8a20-578506088116"
+    },
+    "storage_domains" : {
+      "storage_domain" : [ {
+        "href" : "/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8",
+        "id" : "95ef6fee-5773-46a2-9340-a636958a96b8"
+      } ]
+    },
+    "actions" : {
+      "link" : [ {
+        "href" : "/ovirt-engine/api/disks/44b37123-144b-419d-91c3-ded219373cc7/reduce",
+        "rel" : "reduce"
+      }, {
+        "href" : "/ovirt-engine/api/disks/44b37123-144b-419d-91c3-ded219373cc7/sparsify",
+        "rel" : "sparsify"
+      }, {
+        "href" : "/ovirt-engine/api/disks/44b37123-144b-419d-91c3-ded219373cc7/copy",
+        "rel" : "copy"
+      }, {
+        "href" : "/ovirt-engine/api/disks/44b37123-144b-419d-91c3-ded219373cc7/export",
+        "rel" : "export"
+      }, {
+        "href" : "/ovirt-engine/api/disks/44b37123-144b-419d-91c3-ded219373cc7/move",
+        "rel" : "move"
+      }, {
+        "href" : "/ovirt-engine/api/disks/44b37123-144b-419d-91c3-ded219373cc7/refreshlun",
+        "rel" : "refreshlun"
+      } ]
+    },
+    "name" : "test_Disk1",
+    "description" : "",
+    "href" : "/ovirt-engine/api/disks/44b37123-144b-419d-91c3-ded219373cc7",
+    "id" : "44b37123-144b-419d-91c3-ded219373cc7",
+    "link" : [ {
+      "href" : "/ovirt-engine/api/disks/44b37123-144b-419d-91c3-ded219373cc7/permissions",
+      "rel" : "permissions"
+    }, {
+      "href" : "/ovirt-engine/api/disks/44b37123-144b-419d-91c3-ded219373cc7/disksnapshots",
+      "rel" : "disksnapshots"
+    }, {
+      "href" : "/ovirt-engine/api/disks/44b37123-144b-419d-91c3-ded219373cc7/statistics",
+      "rel" : "statistics"
+    } ]
+  }, {
+    "actual_size" : "4096",
+    "alias" : "test123",
+    "backup" : "none",
+    "content_type" : "data",
+    "format" : "raw",
+    "image_id" : "3b506062-d062-461c-ad51-7daceed9e1b5",
+    "propagate_errors" : "false",
+    "provisioned_size" : "1073741824",
+    "shareable" : "false",
+    "sparse" : "true",
+    "status" : "ok",
+    "storage_type" : "image",
+    "total_size" : "4096",
+    "wipe_after_delete" : "false",
+    "disk_profile" : {
+      "href" : "/ovirt-engine/api/diskprofiles/0f9c5266-0192-4127-897f-b297cf6c8e04",
+      "id" : "0f9c5266-0192-4127-897f-b297cf6c8e04"
+    },
+    "quota" : {
+      "href" : "/ovirt-engine/api/datacenters/32ebd239-25a2-4a13-b514-5bf7c8de6878/quotas/712172d4-dc8e-4989-8a20-578506088116",
+      "id" : "712172d4-dc8e-4989-8a20-578506088116"
+    },
+    "storage_domains" : {
+      "storage_domain" : [ {
+        "href" : "/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8",
+        "id" : "95ef6fee-5773-46a2-9340-a636958a96b8"
+      } ]
+    },
+    "actions" : {
+      "link" : [ {
+        "href" : "/ovirt-engine/api/disks/95158d8b-8105-4287-976b-3c124d7cf393/reduce",
+        "rel" : "reduce"
+      }, {
+        "href" : "/ovirt-engine/api/disks/95158d8b-8105-4287-976b-3c124d7cf393/sparsify",
+        "rel" : "sparsify"
+      }, {
+        "href" : "/ovirt-engine/api/disks/95158d8b-8105-4287-976b-3c124d7cf393/copy",
+        "rel" : "copy"
+      }, {
+        "href" : "/ovirt-engine/api/disks/95158d8b-8105-4287-976b-3c124d7cf393/export",
+        "rel" : "export"
+      }, {
+        "href" : "/ovirt-engine/api/disks/95158d8b-8105-4287-976b-3c124d7cf393/move",
+        "rel" : "move"
+      }, {
+        "href" : "/ovirt-engine/api/disks/95158d8b-8105-4287-976b-3c124d7cf393/refreshlun",
+        "rel" : "refreshlun"
+      } ]
+    },
+    "name" : "test123",
+    "description" : "",
+    "href" : "/ovirt-engine/api/disks/95158d8b-8105-4287-976b-3c124d7cf393",
+    "id" : "95158d8b-8105-4287-976b-3c124d7cf393",
+    "link" : [ {
+      "href" : "/ovirt-engine/api/disks/95158d8b-8105-4287-976b-3c124d7cf393/permissions",
+      "rel" : "permissions"
+    }, {
+      "href" : "/ovirt-engine/api/disks/95158d8b-8105-4287-976b-3c124d7cf393/disksnapshots",
+      "rel" : "disksnapshots"
+    }, {
+      "href" : "/ovirt-engine/api/disks/95158d8b-8105-4287-976b-3c124d7cf393/statistics",
+      "rel" : "statistics"
+    } ]
+  }, {
+    "actual_size" : "1719832576",
+    "alias" : "test_Disk1",
+    "backup" : "none",
+    "content_type" : "data",
+    "format" : "raw",
+    "image_id" : "85752c17-d73f-428a-be2e-404b95afdad5",
+    "propagate_errors" : "false",
+    "provisioned_size" : "8589934592",
+    "shareable" : "false",
+    "sparse" : "true",
+    "status" : "ok",
+    "storage_type" : "image",
+    "total_size" : "1719832576",
+    "wipe_after_delete" : "false",
+    "disk_profile" : {
+      "href" : "/ovirt-engine/api/diskprofiles/0f9c5266-0192-4127-897f-b297cf6c8e04",
+      "id" : "0f9c5266-0192-4127-897f-b297cf6c8e04"
+    },
+    "quota" : {
+      "href" : "/ovirt-engine/api/datacenters/32ebd239-25a2-4a13-b514-5bf7c8de6878/quotas/712172d4-dc8e-4989-8a20-578506088116",
+      "id" : "712172d4-dc8e-4989-8a20-578506088116"
+    },
+    "storage_domains" : {
+      "storage_domain" : [ {
+        "href" : "/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8",
+        "id" : "95ef6fee-5773-46a2-9340-a636958a96b8"
+      } ]
+    },
+    "actions" : {
+      "link" : [ {
+        "href" : "/ovirt-engine/api/disks/b5a7f7f6-377b-467b-850f-a0dcd43ac5d7/reduce",
+        "rel" : "reduce"
+      }, {
+        "href" : "/ovirt-engine/api/disks/b5a7f7f6-377b-467b-850f-a0dcd43ac5d7/sparsify",
+        "rel" : "sparsify"
+      }, {
+        "href" : "/ovirt-engine/api/disks/b5a7f7f6-377b-467b-850f-a0dcd43ac5d7/copy",
+        "rel" : "copy"
+      }, {
+        "href" : "/ovirt-engine/api/disks/b5a7f7f6-377b-467b-850f-a0dcd43ac5d7/export",
+        "rel" : "export"
+      }, {
+        "href" : "/ovirt-engine/api/disks/b5a7f7f6-377b-467b-850f-a0dcd43ac5d7/move",
+        "rel" : "move"
+      }, {
+        "href" : "/ovirt-engine/api/disks/b5a7f7f6-377b-467b-850f-a0dcd43ac5d7/refreshlun",
+        "rel" : "refreshlun"
+      } ]
+    },
+    "name" : "test_Disk1",
+    "description" : "",
+    "href" : "/ovirt-engine/api/disks/b5a7f7f6-377b-467b-850f-a0dcd43ac5d7",
+    "id" : "b5a7f7f6-377b-467b-850f-a0dcd43ac5d7",
+    "link" : [ {
+      "href" : "/ovirt-engine/api/disks/b5a7f7f6-377b-467b-850f-a0dcd43ac5d7/permissions",
+      "rel" : "permissions"
+    }, {
+      "href" : "/ovirt-engine/api/disks/b5a7f7f6-377b-467b-850f-a0dcd43ac5d7/disksnapshots",
+      "rel" : "disksnapshots"
+    }, {
+      "href" : "/ovirt-engine/api/disks/b5a7f7f6-377b-467b-850f-a0dcd43ac5d7/statistics",
+      "rel" : "statistics"
+    } ]
+  } ]
+}

--- a/ovirt/stubs/events/content
+++ b/ovirt/stubs/events/content
@@ -1,0 +1,20 @@
+{
+  "event" : [ {
+    "code" : "30",
+    "correlation_id" : "ed6cd6a",
+    "custom_id" : "-1",
+    "flood_rate" : "0",
+    "index" : "375049",
+    "origin" : "oVirt",
+    "severity" : "normal",
+    "time" : 1666082820375,
+    "user" : {
+      "name" : "admin@internal-authz",
+      "href" : "/ovirt-engine/api/users/bfd9c4d2-89e8-11ec-8d18",
+      "id" : "bfd9c4d2-89e8-11ec-8d18"
+    },
+    "description" : "User admin@internal-authz connecting from '' using session '' logged in.",
+    "href" : "/ovirt-engine/api/events/375049",
+    "id" : "375049"
+  } ]
+}

--- a/ovirt/stubs/hosts/content
+++ b/ovirt/stubs/hosts/content
@@ -1,0 +1,213 @@
+{
+  "host" : [ {
+    "address" : "host.example.com",
+    "auto_numa_status" : "unknown",
+    "certificate" : {
+      "organization" : "example.com",
+      "subject" : "O=example.com,CN=host.example.com"
+    },
+    "cpu" : {
+      "name" : "Westmere E56xx/L56xx/X56xx (Nehalem-C)",
+      "speed" : 2200,
+      "topology" : {
+        "cores" : "1",
+        "sockets" : "4",
+        "threads" : "1"
+      },
+      "type" : "Intel Westmere Family"
+    },
+    "device_passthrough" : {
+      "enabled" : "false"
+    },
+    "external_status" : "ok",
+    "hardware_information" : {
+      "family" : "Red Hat Enterprise Linux",
+      "manufacturer" : "Red Hat",
+      "product_name" : "RHEV Hypervisor",
+      "serial_number" : "4c4c4544-0038-3710-8059-b6c04f4d3632",
+      "supported_rng_sources" : {
+        "supported_rng_source" : [ "hwrng", "random" ]
+      },
+      "uuid" : "8C222E80-6933-4E28-8F15-9B3BCC99C50A",
+      "version" : "7.9-6.el7_9"
+    },
+    "iscsi" : {
+      "initiator" : "iqn.1994-05.com.example:c68a9c47e1cb"
+    },
+    "kdump_status" : "disabled",
+    "ksm" : {
+      "enabled" : "true"
+    },
+    "libvirt_version" : {
+      "build" : "0",
+      "full_version" : "libvirt-8.0.0-2.module_el8.6.0+1087+b42c8331",
+      "major" : "8",
+      "minor" : "0",
+      "revision" : "0"
+    },
+    "max_scheduling_memory" : "2270167040",
+    "memory" : "3910139904",
+    "numa_supported" : "false",
+    "os" : {
+      "custom_kernel_cmdline" : "",
+      "reported_kernel_cmdline" : "BOOT_IMAGE=(hd0,msdos1)/vmlinuz-4.18.0-358.el8.x86_64 root=/dev/mapper/cs_10--37--140--134-root ro crashkernel=auto resume=/dev/mapper/cs_10--37--140--134-swap rd.lvm.lv=cs_10-37-140-134/root rd.lvm.lv=cs_10-37-140-134/swap rhgb quiet",
+      "type" : "RHEL",
+      "version" : {
+        "full_version" : "8.6 - 1.el8",
+        "major" : "8",
+        "minor" : "6"
+      }
+    },
+    "port" : "54321",
+    "power_management" : {
+      "automatic_pm_enabled" : "true",
+      "enabled" : "false",
+      "kdump_detection" : "true",
+      "pm_proxies" : { }
+    },
+    "protocol" : "stomp",
+    "reinstallation_required" : "false",
+    "se_linux" : {
+      "mode" : "enforcing"
+    },
+    "spm" : {
+      "priority" : "5",
+      "status" : "spm"
+    },
+    "ssh" : {
+      "fingerprint" : "SHA256:gwnUee4QbRl85LI3StDaCGtPdfF4+BendzJTyQYTs+I",
+      "port" : "22",
+      "public_key" : "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHIDgsxyz8SRyUTVf3SVizVlTZm9uQwboBBtrFlQaBd29LPl686+GPR89PwiOCqi0IDFGN06vSbOwLJswYqEOzM="
+    },
+    "status" : "up",
+    "summary" : {
+      "active" : "1",
+      "migrating" : "0",
+      "total" : "1"
+    },
+    "transparent_hugepages" : {
+      "enabled" : "true"
+    },
+    "type" : "rhel",
+    "update_available" : "true",
+    "version" : {
+      "build" : "100",
+      "full_version" : "vdsm-4.40.100.2-1.el8",
+      "major" : "4",
+      "minor" : "40",
+      "revision" : "2"
+    },
+    "vgpu_placement" : "consolidated",
+    "cluster" : {
+      "href" : "/ovirt-engine/api/clusters/b94f0a35-8ed8-429c-999a-4d776640107e",
+      "id" : "b94f0a35-8ed8-429c-999a-4d776640107e"
+    },
+    "actions" : {
+      "link" : [ {
+        "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/install",
+        "rel" : "install"
+      }, {
+        "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/activate",
+        "rel" : "activate"
+      }, {
+        "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/deactivate",
+        "rel" : "deactivate"
+      }, {
+        "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/syncallnetworks",
+        "rel" : "syncallnetworks"
+      }, {
+        "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/approve",
+        "rel" : "approve"
+      }, {
+        "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/commitnetconfig",
+        "rel" : "commitnetconfig"
+      }, {
+        "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/enrollcertificate",
+        "rel" : "enrollcertificate"
+      }, {
+        "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/fence",
+        "rel" : "fence"
+      }, {
+        "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/forceselectspm",
+        "rel" : "forceselectspm"
+      }, {
+        "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/iscsidiscover",
+        "rel" : "iscsidiscover"
+      }, {
+        "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/discoveriscsi",
+        "rel" : "discoveriscsi"
+      }, {
+        "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/iscsilogin",
+        "rel" : "iscsilogin"
+      }, {
+        "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/upgrade",
+        "rel" : "upgrade"
+      }, {
+        "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/unregisteredstoragedomainsdiscover",
+        "rel" : "unregisteredstoragedomainsdiscover"
+      }, {
+        "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/upgradecheck",
+        "rel" : "upgradecheck"
+      }, {
+        "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/copyhostnetworks",
+        "rel" : "copyhostnetworks"
+      }, {
+        "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/setupnetworks",
+        "rel" : "setupnetworks"
+      }, {
+        "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/refresh",
+        "rel" : "refresh"
+      } ]
+    },
+    "name" : "vhost",
+    "comment" : "",
+    "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1",
+    "id" : "2900d577-63a8-4ec9-acff-8493278346b1",
+    "link" : [ {
+      "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/fenceagents",
+      "rel" : "fenceagents"
+    }, {
+      "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/devices",
+      "rel" : "devices"
+    }, {
+      "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/hooks",
+      "rel" : "hooks"
+    }, {
+      "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/nics",
+      "rel" : "nics"
+    }, {
+      "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/numanodes",
+      "rel" : "numanodes"
+    }, {
+      "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/storage",
+      "rel" : "storage"
+    }, {
+      "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/networkattachments",
+      "rel" : "networkattachments"
+    }, {
+      "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/storageconnectionextensions",
+      "rel" : "storageconnectionextensions"
+    }, {
+      "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/unmanagednetworks",
+      "rel" : "unmanagednetworks"
+    }, {
+      "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/externalnetworkproviderconfigurations",
+      "rel" : "externalnetworkproviderconfigurations"
+    }, {
+      "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/katelloerrata",
+      "rel" : "katelloerrata"
+    }, {
+      "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/permissions",
+      "rel" : "permissions"
+    }, {
+      "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/affinitylabels",
+      "rel" : "affinitylabels"
+    }, {
+      "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/tags",
+      "rel" : "tags"
+    }, {
+      "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1/statistics",
+      "rel" : "statistics"
+    } ]
+  } ]
+}

--- a/ovirt/stubs/networks/content
+++ b/ovirt/stubs/networks/content
@@ -1,0 +1,30 @@
+{
+  "network" : [ {
+    "mtu" : "0",
+    "port_isolation" : "false",
+    "stp" : "false",
+    "usages" : {
+      "usage" : [ "vm" ]
+    },
+    "vdsm_name" : "ovirtmgmt",
+    "data_center" : {
+      "href" : "/ovirt-engine/api/datacenters/32ebd239-25a2-4a13-b514-5bf7c8de6878",
+      "id" : "32ebd239-25a2-4a13-b514-5bf7c8de6878"
+    },
+    "name" : "ovirtmgmt",
+    "description" : "Default Management Network",
+    "comment" : "",
+    "href" : "/ovirt-engine/api/networks/6b6b7239-5ea1-4f08-a76e-be150ab8eb89",
+    "id" : "6b6b7239-5ea1-4f08-a76e-be150ab8eb89",
+    "link" : [ {
+      "href" : "/ovirt-engine/api/networks/6b6b7239-5ea1-4f08-a76e-be150ab8eb89/networklabels",
+      "rel" : "networklabels"
+    }, {
+      "href" : "/ovirt-engine/api/networks/6b6b7239-5ea1-4f08-a76e-be150ab8eb89/permissions",
+      "rel" : "permissions"
+    }, {
+      "href" : "/ovirt-engine/api/networks/6b6b7239-5ea1-4f08-a76e-be150ab8eb89/vnicprofiles",
+      "rel" : "vnicprofiles"
+    } ]
+  } ]
+}

--- a/ovirt/stubs/storagedomains/content
+++ b/ovirt/stubs/storagedomains/content
@@ -1,0 +1,125 @@
+{
+  "storage_domain" : [ {
+    "backup" : "false",
+    "block_size" : "512",
+    "committed" : "0",
+    "critical_space_action_blocker" : "0",
+    "discard_after_delete" : "false",
+    "external_status" : "ok",
+    "master" : "false",
+    "status" : "unattached",
+    "storage" : {
+      "type" : "glance"
+    },
+    "storage_format" : "v1",
+    "supports_discard" : "false",
+    "supports_discard_zeroes_data" : "false",
+    "type" : "image",
+    "warning_low_space_indicator" : "0",
+    "wipe_after_delete" : "false",
+    "actions" : {
+      "link" : [ {
+        "href" : "/ovirt-engine/api/storagedomains/072fbaa1-08f3-4a40-9f34-a5ca22dd1d74/isattached",
+        "rel" : "isattached"
+      }, {
+        "href" : "/ovirt-engine/api/storagedomains/072fbaa1-08f3-4a40-9f34-a5ca22dd1d74/updateovfstore",
+        "rel" : "updateovfstore"
+      }, {
+        "href" : "/ovirt-engine/api/storagedomains/072fbaa1-08f3-4a40-9f34-a5ca22dd1d74/refreshluns",
+        "rel" : "refreshluns"
+      }, {
+        "href" : "/ovirt-engine/api/storagedomains/072fbaa1-08f3-4a40-9f34-a5ca22dd1d74/reduceluns",
+        "rel" : "reduceluns"
+      } ]
+    },
+    "name" : "ovirt-image-repository",
+    "description" : "",
+    "comment" : "",
+    "href" : "/ovirt-engine/api/storagedomains/072fbaa1-08f3-4a40-9f34-a5ca22dd1d74",
+    "id" : "072fbaa1-08f3-4a40-9f34-a5ca22dd1d74",
+    "link" : [ {
+      "href" : "/ovirt-engine/api/storagedomains/072fbaa1-08f3-4a40-9f34-a5ca22dd1d74/diskprofiles",
+      "rel" : "diskprofiles"
+    }, {
+      "href" : "/ovirt-engine/api/storagedomains/072fbaa1-08f3-4a40-9f34-a5ca22dd1d74/permissions",
+      "rel" : "permissions"
+    }, {
+      "href" : "/ovirt-engine/api/storagedomains/072fbaa1-08f3-4a40-9f34-a5ca22dd1d74/disksnapshots",
+      "rel" : "disksnapshots"
+    }, {
+      "href" : "/ovirt-engine/api/storagedomains/072fbaa1-08f3-4a40-9f34-a5ca22dd1d74/images",
+      "rel" : "images"
+    } ]
+  }, {
+    "available" : "7516192768",
+    "backup" : "false",
+    "block_size" : "512",
+    "committed" : "76235669504",
+    "critical_space_action_blocker" : "5",
+    "discard_after_delete" : "false",
+    "external_status" : "ok",
+    "master" : "true",
+    "storage" : {
+      "address" : "host.example.com",
+      "nfs_timeo" : "200",
+      "nfs_version" : "v4",
+      "path" : "/exports/data",
+      "type" : "nfs"
+    },
+    "storage_format" : "v5",
+    "supports_discard" : "false",
+    "supports_discard_zeroes_data" : "false",
+    "type" : "data",
+    "used" : "9663676416",
+    "warning_low_space_indicator" : "10",
+    "wipe_after_delete" : "false",
+    "data_centers" : {
+      "data_center" : [ {
+        "href" : "/ovirt-engine/api/datacenters/32ebd239-25a2-4a13-b514-5bf7c8de6878",
+        "id" : "32ebd239-25a2-4a13-b514-5bf7c8de6878"
+      } ]
+    },
+    "actions" : {
+      "link" : [ {
+        "href" : "/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8/isattached",
+        "rel" : "isattached"
+      }, {
+        "href" : "/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8/updateovfstore",
+        "rel" : "updateovfstore"
+      }, {
+        "href" : "/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8/refreshluns",
+        "rel" : "refreshluns"
+      }, {
+        "href" : "/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8/reduceluns",
+        "rel" : "reduceluns"
+      } ]
+    },
+    "name" : "test",
+    "description" : "",
+    "comment" : "",
+    "href" : "/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8",
+    "id" : "95ef6fee-5773-46a2-9340-a636958a96b8",
+    "link" : [ {
+      "href" : "/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8/diskprofiles",
+      "rel" : "diskprofiles"
+    }, {
+      "href" : "/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8/disks",
+      "rel" : "disks"
+    }, {
+      "href" : "/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8/storageconnections",
+      "rel" : "storageconnections"
+    }, {
+      "href" : "/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8/permissions",
+      "rel" : "permissions"
+    }, {
+      "href" : "/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8/templates",
+      "rel" : "templates"
+    }, {
+      "href" : "/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8/vms",
+      "rel" : "vms"
+    }, {
+      "href" : "/ovirt-engine/api/storagedomains/95ef6fee-5773-46a2-9340-a636958a96b8/disksnapshots",
+      "rel" : "disksnapshots"
+    } ]
+  } ]
+}

--- a/ovirt/stubs/vms/content
+++ b/ovirt/stubs/vms/content
@@ -1,0 +1,484 @@
+{
+  "vm" : [ {
+    "next_run_configuration_exists" : "false",
+    "status" : "down",
+    "stop_reason" : "",
+    "stop_time" : 1665070703215,
+    "original_template" : {
+      "href" : "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000",
+      "id" : "00000000-0000-0000-0000-000000000000"
+    },
+    "template" : {
+      "href" : "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000",
+      "id" : "00000000-0000-0000-0000-000000000000"
+    },
+    "actions" : {
+      "link" : [ {
+        "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/detach",
+        "rel" : "detach"
+      }, {
+        "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/shutdown",
+        "rel" : "shutdown"
+      }, {
+        "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/start",
+        "rel" : "start"
+      }, {
+        "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/stop",
+        "rel" : "stop"
+      }, {
+        "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/suspend",
+        "rel" : "suspend"
+      }, {
+        "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/reset",
+        "rel" : "reset"
+      }, {
+        "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/ticket",
+        "rel" : "ticket"
+      }, {
+        "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/migrate",
+        "rel" : "migrate"
+      }, {
+        "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/reboot",
+        "rel" : "reboot"
+      }, {
+        "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/commitsnapshot",
+        "rel" : "commitsnapshot"
+      }, {
+        "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/clone",
+        "rel" : "clone"
+      }, {
+        "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/freezefilesystems",
+        "rel" : "freezefilesystems"
+      }, {
+        "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/logon",
+        "rel" : "logon"
+      }, {
+        "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/maintenance",
+        "rel" : "maintenance"
+      }, {
+        "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/previewsnapshot",
+        "rel" : "previewsnapshot"
+      }, {
+        "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/autopincpuandnumanodes",
+        "rel" : "autopincpuandnumanodes"
+      }, {
+        "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/reordermacaddresses",
+        "rel" : "reordermacaddresses"
+      }, {
+        "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/thawfilesystems",
+        "rel" : "thawfilesystems"
+      }, {
+        "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/undosnapshot",
+        "rel" : "undosnapshot"
+      }, {
+        "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/cancelmigration",
+        "rel" : "cancelmigration"
+      }, {
+        "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/export",
+        "rel" : "export"
+      } ]
+    },
+    "name" : "test",
+    "description" : "",
+    "comment" : "",
+    "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae",
+    "id" : "f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae",
+    "bios" : {
+      "boot_menu" : {
+        "enabled" : "false"
+      },
+      "type" : "q35_sea_bios"
+    },
+    "cpu" : {
+      "architecture" : "x86_64",
+      "topology" : {
+        "cores" : "1",
+        "sockets" : "1",
+        "threads" : "1"
+      }
+    },
+    "display" : {
+      "allow_override" : "false",
+      "copy_paste_enabled" : "true",
+      "disconnect_action" : "LOCK_SCREEN",
+      "file_transfer_enabled" : "true",
+      "monitors" : "1",
+      "smartcard_enabled" : "false",
+      "type" : "spice"
+    },
+    "io" : {
+      "threads" : "1"
+    },
+    "memory" : "1073741824",
+    "migration" : {
+      "auto_converge" : "inherit",
+      "compressed" : "inherit",
+      "encrypted" : "inherit"
+    },
+    "origin" : "ovirt",
+    "os" : {
+      "boot" : {
+        "devices" : {
+          "device" : [ "hd" ]
+        }
+      },
+      "type" : "other"
+    },
+    "sso" : {
+      "methods" : {
+        "method" : [ {
+          "id" : "guest_agent"
+        } ]
+      }
+    },
+    "stateless" : "false",
+    "type" : "server",
+    "usb" : {
+      "enabled" : "false"
+    },
+    "cluster" : {
+      "href" : "/ovirt-engine/api/clusters/b94f0a35-8ed8-429c-999a-4d776640107e",
+      "id" : "b94f0a35-8ed8-429c-999a-4d776640107e"
+    },
+    "quota" : {
+      "id" : "712172d4-dc8e-4989-8a20-578506088116"
+    },
+    "link" : [ {
+      "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/graphicsconsoles",
+      "rel" : "graphicsconsoles"
+    }, {
+      "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/cdroms",
+      "rel" : "cdroms"
+    }, {
+      "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/watchdogs",
+      "rel" : "watchdogs"
+    }, {
+      "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/diskattachments",
+      "rel" : "diskattachments"
+    }, {
+      "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/snapshots",
+      "rel" : "snapshots"
+    }, {
+      "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/applications",
+      "rel" : "applications"
+    }, {
+      "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/hostdevices",
+      "rel" : "hostdevices"
+    }, {
+      "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/reporteddevices",
+      "rel" : "reporteddevices"
+    }, {
+      "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/sessions",
+      "rel" : "sessions"
+    }, {
+      "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/backups",
+      "rel" : "backups"
+    }, {
+      "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/checkpoints",
+      "rel" : "checkpoints"
+    }, {
+      "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/nics",
+      "rel" : "nics"
+    }, {
+      "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/numanodes",
+      "rel" : "numanodes"
+    }, {
+      "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/katelloerrata",
+      "rel" : "katelloerrata"
+    }, {
+      "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/permissions",
+      "rel" : "permissions"
+    }, {
+      "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/affinitylabels",
+      "rel" : "affinitylabels"
+    }, {
+      "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/tags",
+      "rel" : "tags"
+    }, {
+      "href" : "/ovirt-engine/api/vms/f8501be6-adb2-4c40-9ea6-fbb2d9cd6bae/statistics",
+      "rel" : "statistics"
+    } ],
+    "cpu_shares" : "0",
+    "creation_time" : 1664884160476,
+    "delete_protected" : "false",
+    "high_availability" : {
+      "enabled" : "false",
+      "priority" : "1"
+    },
+    "large_icon" : {
+      "href" : "/ovirt-engine/api/icons/b34cbd6a-a64b-4718-a0bb-f7166f696ab2",
+      "id" : "b34cbd6a-a64b-4718-a0bb-f7166f696ab2"
+    },
+    "memory_policy" : {
+      "ballooning" : "true",
+      "guaranteed" : "1073741824",
+      "max" : "4294967296"
+    },
+    "migration_downtime" : "-1",
+    "multi_queues_enabled" : "true",
+    "placement_policy" : {
+      "affinity" : "migratable"
+    },
+    "small_icon" : {
+      "href" : "/ovirt-engine/api/icons/25581ebc-c80e-4571-a088-3a058561ca50",
+      "id" : "25581ebc-c80e-4571-a088-3a058561ca50"
+    },
+    "start_paused" : "false",
+    "storage_error_resume_behaviour" : "auto_resume",
+    "time_zone" : {
+      "name" : "Etc/GMT"
+    },
+    "virtio_scsi_multi_queues_enabled" : "false",
+    "cpu_profile" : {
+      "href" : "/ovirt-engine/api/cpuprofiles/597667d4-042c-4631-8257-f978ac18ae6c",
+      "id" : "597667d4-042c-4631-8257-f978ac18ae6c"
+    }
+  }, {
+    "next_run_configuration_exists" : "false",
+    "run_once" : "true",
+    "start_time" : 1665068746731,
+    "status" : "up",
+    "stop_time" : 1665068704656,
+    "host" : {
+      "href" : "/ovirt-engine/api/hosts/2900d577-63a8-4ec9-acff-8493278346b1",
+      "id" : "2900d577-63a8-4ec9-acff-8493278346b1"
+    },
+    "original_template" : {
+      "href" : "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000",
+      "id" : "00000000-0000-0000-0000-000000000000"
+    },
+    "template" : {
+      "href" : "/ovirt-engine/api/templates/00000000-0000-0000-0000-000000000000",
+      "id" : "00000000-0000-0000-0000-000000000000"
+    },
+    "actions" : {
+      "link" : [ {
+        "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/detach",
+        "rel" : "detach"
+      }, {
+        "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/shutdown",
+        "rel" : "shutdown"
+      }, {
+        "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/start",
+        "rel" : "start"
+      }, {
+        "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/stop",
+        "rel" : "stop"
+      }, {
+        "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/suspend",
+        "rel" : "suspend"
+      }, {
+        "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/reset",
+        "rel" : "reset"
+      }, {
+        "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/ticket",
+        "rel" : "ticket"
+      }, {
+        "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/migrate",
+        "rel" : "migrate"
+      }, {
+        "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/reboot",
+        "rel" : "reboot"
+      }, {
+        "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/commitsnapshot",
+        "rel" : "commitsnapshot"
+      }, {
+        "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/clone",
+        "rel" : "clone"
+      }, {
+        "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/freezefilesystems",
+        "rel" : "freezefilesystems"
+      }, {
+        "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/logon",
+        "rel" : "logon"
+      }, {
+        "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/maintenance",
+        "rel" : "maintenance"
+      }, {
+        "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/previewsnapshot",
+        "rel" : "previewsnapshot"
+      }, {
+        "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/autopincpuandnumanodes",
+        "rel" : "autopincpuandnumanodes"
+      }, {
+        "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/reordermacaddresses",
+        "rel" : "reordermacaddresses"
+      }, {
+        "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/thawfilesystems",
+        "rel" : "thawfilesystems"
+      }, {
+        "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/undosnapshot",
+        "rel" : "undosnapshot"
+      }, {
+        "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/cancelmigration",
+        "rel" : "cancelmigration"
+      }, {
+        "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/export",
+        "rel" : "export"
+      } ]
+    },
+    "name" : "test123",
+    "description" : "",
+    "comment" : "",
+    "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1",
+    "id" : "31573c08-717b-43e0-825f-69a36fb0e1a1",
+    "bios" : {
+      "boot_menu" : {
+        "enabled" : "false"
+      },
+      "type" : "q35_sea_bios"
+    },
+    "cpu" : {
+      "architecture" : "x86_64",
+      "topology" : {
+        "cores" : "1",
+        "sockets" : "1",
+        "threads" : "1"
+      }
+    },
+    "display" : {
+      "address" : "10.37.140.134",
+      "allow_override" : "false",
+      "certificate" : {
+        "content" : "-----BEGIN CERTIFICATE-----\nMIIEMjCCAxqgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwbDELMAkGA1UEBhMCVVMxJDAiBgNVBAoM\nG3JoZXYubGFiLmVuZy5icnEucmVkaGF0LmNvbTE3MDUGA1UEAwwuMTAtMzctMTQwLTg1LnJoZXYu\nbGFiLmVuZy5icnEucmVkaGF0LmNvbS4xOTk2NjAeFw0yMjAyMDgyMDQwMDRaFw0zMjAyMDcyMDQw\nMDRaMGwxCzAJBgNVBAYTAlVTMSQwIgYDVQQKDBtyaGV2LmxhYi5lbmcuYnJxLnJlZGhhdC5jb20x\nNzA1BgNVBAMMLjEwLTM3LTE0MC04NS5yaGV2LmxhYi5lbmcuYnJxLnJlZGhhdC5jb20uMTk5NjYw\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQClXaDqD6/jbFaW1w8W/z9b9fRYbP2kTqwO\n7b2HpBQ+ku2oe8pbNw7PeydtPgvlvnYaBn72GPKAfdBy4oYnQtc7QZHVm59gZ+FwSL1/YJHV+xe9\nzty06OiT6PyeFgXTMQm3TXTcGkddmEc3wr9jslo5XtLRbcUnoYspr/DNJbYsZ840jeF5vVRIWxtv\nZAesifEEXJLf4ayrZLq/1F+qGriTz8Az0ZRx248GfBk9mZAKOOFZYyf7VciOeblnxO2RpGUKbapf\nPr0e4jzV34rcmEcWeXiE0bzFe8pjtxipKbXfjIjNZYfeQNo/pjih8k450/9EdCIsZ2iToGHMqWzd\nPOKLAgMBAAGjgd0wgdowHQYDVR0OBBYEFI3HJZyE9PkQS/wspjGf6Yx8Sv2YMIGXBgNVHSMEgY8w\ngYyAFI3HJZyE9PkQS/wspjGf6Yx8Sv2YoXCkbjBsMQswCQYDVQQGEwJVUzEkMCIGA1UECgwbcmhl\ndi5sYWIuZW5nLmJycS5yZWRoYXQuY29tMTcwNQYDVQQDDC4xMC0zNy0xNDAtODUucmhldi5sYWIu\nZW5nLmJycS5yZWRoYXQuY29tLjE5OTY2ggIQADAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQE\nAwIBBjANBgkqhkiG9w0BAQsFAAOCAQEAOJ4RjpJ2L/aTAcVspYZilhZMpuhimz3sYEPByCj+wm7i\n3fEMtJc3k5j5RHTTlQGTSqUTTNTJhDuAth9Hq+KQfqhItCymLGwNYsLuqg7HLew7Y/PbVrSWqX87\n4mMycsXFg7eLBNkwN8BcxkN2wTJ/cSvgIF0nQ36N7lcLmp2gqgAcsHsSgMyNU+SQ55YDLDJS1k7i\nPkR6ku44P/ZgTvsR7Z1e7Pzs6umzimH+9RJGIhhPkwaHpzTs6I9pI+BRx6JS+0/GxYOn4hU/Ll4j\nn0aYi/8/pHQy41rsPjVEqfncPJam78a5CwnL1xaLfX3W4JHAwEw7fdJnMfKYhKDq+jAGXw==\n-----END CERTIFICATE-----\n",
+        "organization" : "rhev.lab.eng.brq.redhat.com",
+        "subject" : "O=rhev.lab.eng.brq.redhat.com,CN=10-37-140-134.rhev.lab.eng.brq2.redhat.com"
+      },
+      "copy_paste_enabled" : "true",
+      "disconnect_action" : "LOCK_SCREEN",
+      "file_transfer_enabled" : "true",
+      "monitors" : "1",
+      "port" : "5903",
+      "secure_port" : "5904",
+      "smartcard_enabled" : "false",
+      "type" : "spice"
+    },
+    "io" : {
+      "threads" : "1"
+    },
+    "memory" : "1073741824",
+    "migration" : {
+      "auto_converge" : "inherit",
+      "compressed" : "inherit",
+      "encrypted" : "inherit"
+    },
+    "origin" : "ovirt",
+    "os" : {
+      "boot" : {
+        "devices" : {
+          "device" : [ "cdrom", "hd", "network" ]
+        }
+      },
+      "type" : "other"
+    },
+    "sso" : {
+      "methods" : {
+        "method" : [ {
+          "id" : "guest_agent"
+        } ]
+      }
+    },
+    "stateless" : "false",
+    "type" : "server",
+    "usb" : {
+      "enabled" : "false"
+    },
+    "cluster" : {
+      "href" : "/ovirt-engine/api/clusters/b94f0a35-8ed8-429c-999a-4d776640107e",
+      "id" : "b94f0a35-8ed8-429c-999a-4d776640107e"
+    },
+    "quota" : {
+      "id" : "712172d4-dc8e-4989-8a20-578506088116"
+    },
+    "link" : [ {
+      "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/graphicsconsoles",
+      "rel" : "graphicsconsoles"
+    }, {
+      "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/cdroms",
+      "rel" : "cdroms"
+    }, {
+      "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/watchdogs",
+      "rel" : "watchdogs"
+    }, {
+      "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/diskattachments",
+      "rel" : "diskattachments"
+    }, {
+      "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/snapshots",
+      "rel" : "snapshots"
+    }, {
+      "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/applications",
+      "rel" : "applications"
+    }, {
+      "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/hostdevices",
+      "rel" : "hostdevices"
+    }, {
+      "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/reporteddevices",
+      "rel" : "reporteddevices"
+    }, {
+      "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/sessions",
+      "rel" : "sessions"
+    }, {
+      "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/backups",
+      "rel" : "backups"
+    }, {
+      "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/checkpoints",
+      "rel" : "checkpoints"
+    }, {
+      "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/nics",
+      "rel" : "nics"
+    }, {
+      "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/numanodes",
+      "rel" : "numanodes"
+    }, {
+      "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/katelloerrata",
+      "rel" : "katelloerrata"
+    }, {
+      "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/permissions",
+      "rel" : "permissions"
+    }, {
+      "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/affinitylabels",
+      "rel" : "affinitylabels"
+    }, {
+      "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/tags",
+      "rel" : "tags"
+    }, {
+      "href" : "/ovirt-engine/api/vms/31573c08-717b-43e0-825f-69a36fb0e1a1/statistics",
+      "rel" : "statistics"
+    } ],
+    "cpu_shares" : "0",
+    "creation_time" : 1665068704618,
+    "delete_protected" : "false",
+    "high_availability" : {
+      "enabled" : "false",
+      "priority" : "1"
+    },
+    "large_icon" : {
+      "href" : "/ovirt-engine/api/icons/b34cbd6a-a64b-4718-a0bb-f7166f696ab2",
+      "id" : "b34cbd6a-a64b-4718-a0bb-f7166f696ab2"
+    },
+    "memory_policy" : {
+      "ballooning" : "true",
+      "guaranteed" : "1073741824",
+      "max" : "4294967296"
+    },
+    "migration_downtime" : "-1",
+    "multi_queues_enabled" : "true",
+    "placement_policy" : {
+      "affinity" : "migratable"
+    },
+    "small_icon" : {
+      "href" : "/ovirt-engine/api/icons/25581ebc-c80e-4571-a088-3a058561ca50",
+      "id" : "25581ebc-c80e-4571-a088-3a058561ca50"
+    },
+    "start_paused" : "false",
+    "storage_error_resume_behaviour" : "auto_resume",
+    "time_zone" : {
+      "name" : "Etc/GMT"
+    },
+    "virtio_scsi_multi_queues_enabled" : "false",
+    "cpu_profile" : {
+      "href" : "/ovirt-engine/api/cpuprofiles/597667d4-042c-4631-8257-f978ac18ae6c",
+      "id" : "597667d4-042c-4631-8257-f978ac18ae6c"
+    }
+  } ]
+}


### PR DESCRIPTION
Similar to https://github.com/kubev2v/forkliftci/pull/4
The patch does:
- setup of fakeovirt form quay.io/mnecas0/fakeovirt
- copy of the stubs to the new image which will be pushed to the local registry
- add the mocked provider to forklift
This patch is only for creating of providers not migrating of disks