### PR TITLE
Add default 'host' kubevirt provider

### DIFF
--- a/build_and_setup_everything_bazel.sh
+++ b/build_and_setup_everything_bazel.sh
@@ -2,6 +2,8 @@
 
 . ./kind_with_registry.sh
 
+./k8s-deploy-kubevirt.sh
+
 ./build_forklift_bazel.sh
 
 ./deploy_local_forklift_bazel.sh
@@ -9,8 +11,6 @@
 ./vmware/setup.sh
 
 ./ovirt/setup.sh
-
-./k8s-deploy-kubevirt.sh
 
 . ./grant_permissions.sh
 

--- a/build_and_setup_everything_bazel_manually.sh
+++ b/build_and_setup_everything_bazel_manually.sh
@@ -4,6 +4,8 @@
 
 ./get_forklift_bazel.sh
 
+./k8s-deploy-kubevirt.sh
+
 ./build_forklift_bazel.sh
 
 ./deploy_local_forklift_bazel.sh
@@ -11,8 +13,6 @@
 ./vmware/setup.sh
 
 ./ovirt/setup.sh
-
-./k8s-deploy-kubevirt.sh
 
 . ./grant_permissions.sh
 


### PR DESCRIPTION
We need to install kubevirt before the forklift so the operator sets up the default host provider
https://github.com/kubev2v/forklift/blob/f122b050fda71942a14cb8fb01613f3e2ded2928/operator/roles/forkliftcontroller/tasks/main.yml#L77-L81