### PR TITLE
Follow github redirect with curl

### DIFF
--- a/k8s-deploy-forklift.sh
+++ b/k8s-deploy-forklift.sh
@@ -11,7 +11,7 @@ while ! kubectl get deployment -n olm olm-operator; do sleep 10; done
 kubectl wait deployment -n olm olm-operator --for condition=Available=True --timeout=180s
 
 # Install forklift-operator
-export FORK_RELEASE=$(curl -s https://api.github.com/repos/konveyor/forklift-operator/branches | jq ". | last .name" | tr -d '"')
+export FORK_RELEASE=$(curl -L -s https://api.github.com/repos/konveyor/forklift-operator/branches | jq ". | last .name" | tr -d '"')
 kubectl apply -f https://raw.githubusercontent.com/konveyor/forklift-operator/${FORK_RELEASE}/forklift-k8s.yaml
 
 # --------------------


### PR DESCRIPTION
follow  GH redirect with curl.
```curl -s https://api.github.com/repos/konveyor/forklift-operator/branches | jq
{
  "message": "Moved Permanently",
  "url": "https://api.github.com/repositories/269193786/branches",
  "documentation_url": "https://docs.github.com/v3/#http-redirects"
}```



Signed-off-by: Evgeny Slutsky <eslutsky@redhat.com>