### PR TITLE
Expose fakeovirt api to cluster node

### DIFF
--- a/build_and_setup_everything_bazel.sh
+++ b/build_and_setup_everything_bazel.sh
@@ -16,3 +16,4 @@
 
 echo "CLUSTER=$CLUSTER"
 echo "TOKEN=$TOKEN"
+echo "NODE_IP=$NODE_IP"

--- a/build_and_setup_everything_bazel_manually.sh
+++ b/build_and_setup_everything_bazel_manually.sh
@@ -18,3 +18,4 @@
 
 echo "CLUSTER=$CLUSTER"
 echo "TOKEN=$TOKEN"
+echo "NODE_IP=$NODE_IP"

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -5,3 +5,6 @@ nodes:
     extraMounts:
       - hostPath: /tmp/kind_storage
         containerPath: /data
+    extraPortMappings:
+    - containerPort: 30001
+      hostPort: 30001

--- a/kind_with_registry.sh
+++ b/kind_with_registry.sh
@@ -59,3 +59,4 @@ EOF
 kubectl apply -f add_pv.yml
 
 export CLUSTER=`kind get kubeconfig | grep server | cut -d ' ' -f6`
+export NODE_IP=`kubectl get nodes -o wide | grep control-plane | awk '{print $6}'`

--- a/ovirt/Dockerfile
+++ b/ovirt/Dockerfile
@@ -3,3 +3,6 @@ FROM quay.io/mnecas0/fakeovirt:latest
 WORKDIR /app
 
 COPY stubs stubs
+
+ENV PORT=30001
+EXPOSE 30001

--- a/ovirt/fakeovirt_deployment.yml
+++ b/ovirt/fakeovirt_deployment.yml
@@ -18,12 +18,12 @@ spec:
       - name: fakeovirt
         image: localhost:5001/fakeovirt:latest
         ports:
-        - containerPort: 12346
+        - containerPort: 30001
         env:
           - name: NAMESPACE
             value: konveyor-forklift
           - name: PORT
-            value: "12346"
+            value: "30001"
 
 ---
 apiVersion: v1
@@ -34,8 +34,8 @@ metadata:
 spec:
   selector:
     app: fakeovirt
-  type: ClusterIP
+  type: NodePort
   ports:
   - name: fakeovirt
-    port: 12346
-    targetPort: 12346
+    port: 30001
+    nodePort: 30001

--- a/ovirt/forklift_provider.yml
+++ b/ovirt/forklift_provider.yml
@@ -27,4 +27,4 @@ spec:
     name: ovirt-provider-secret
     namespace: konveyor-forklift
   type: ovirt
-  url: https://fakeovirt.konveyor-forklift:12346/ovirt-engine/api
+  url: https://fakeovirt.konveyor-forklift:30001/ovirt-engine/api


### PR DESCRIPTION
This patch enables us to access the fakeovirt API from outside of the cluster.
It exposes it on `https://${NODE_IP}:30001/ovirt-engine/api`