### PR TITLE
migrating VMs from vmware using vcsim and fake vddk.

### DIFF
--- a/k8s-deploy-kubevirt.sh
+++ b/k8s-deploy-kubevirt.sh
@@ -15,7 +15,7 @@ kubectl apply -f https://github.com/kubevirt/cluster-network-addons-operator/rel
 kubectl apply -f https://github.com/kubevirt/cluster-network-addons-operator/releases/download/$CNA_VERSION/operator.yaml
 
 # Install kubevirt
-export VIRT_VERSION=v0.57.1
+export VIRT_VERSION=v0.58.0
 #$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases | grep tag_name | grep -v -- '-rc' | sort -r | head -1 | awk -F': ' '{print $2}' | sed 's/,//' | xargs)
 kubectl create -f https://github.com/kubevirt/kubevirt/releases/download/${VIRT_VERSION}/kubevirt-operator.yaml
 kubectl create -f https://github.com/kubevirt/kubevirt/releases/download/${VIRT_VERSION}/kubevirt-cr.yaml

--- a/vmware/manual_deploy_migration_vsphere.yml
+++ b/vmware/manual_deploy_migration_vsphere.yml
@@ -1,0 +1,79 @@
+---
+apiVersion: forklift.konveyor.io/v1beta1
+kind: StorageMap
+metadata:
+  name: test-storage-map-v
+  namespace: konveyor-forklift
+spec:
+  map:
+    - destination:
+        storageClass: standard
+      source:
+        id: datastore-52
+  provider:
+    destination:
+      name: host
+      namespace: konveyor-forklift
+    source:
+      name: vsphere-provider
+      namespace: konveyor-forklift
+
+---
+apiVersion: forklift.konveyor.io/v1beta1
+kind: NetworkMap
+metadata:
+  name: test-network-map-v
+  namespace: konveyor-forklift
+spec:
+  map:
+    - destination:
+        type: pod
+      source:
+        id: dvportgroup-13
+  provider:
+    destination:
+      name: host
+      namespace: konveyor-forklift
+    source:
+      name: vsphere-provider
+      namespace: konveyor-forklift
+
+---
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Plan
+metadata:
+  name: test-v
+  namespace: konveyor-forklift
+spec:
+  archived: false
+  description: ''
+  map:
+    network:
+      name: test-network-map-v
+      namespace: konveyor-forklift
+    storage:
+      name: test-storage-map-v
+      namespace: konveyor-forklift
+  provider:
+    destination:
+      name: host
+      namespace: konveyor-forklift
+    source:
+      name: vsphere-provider
+      namespace: konveyor-forklift
+  targetNamespace: default
+  vms:
+    - hooks: []
+      name: DC0_H0_VM0
+  warm: false
+
+---
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Migration
+metadata:
+  name: test-1664181665570-v
+  namespace: konveyor-forklift
+spec:
+  plan:
+    name: test-v
+    namespace: konveyor-forklift

--- a/vmware/vsphere_provider.yml
+++ b/vmware/vsphere_provider.yml
@@ -24,6 +24,6 @@ spec:
     name: vsphere-provider-secret
     namespace: konveyor-forklift
   settings:
-    vddkInitImage: 'quay.io/lrotenbe/vddk:7.0.3'
+    vddkInitImage: 'quay.io/kubevirt/vddk-test'
   type: vsphere
-  url: 'https://vcsim:8989/sdk'
+  url: 'https://vcsim.konveyor-forklift:8989/sdk'


### PR DESCRIPTION
introducing vddk-test-image  that is built by cdi [https://github.com/kubevirt/containerized-data-importer/tree/main/tools/vddk-test](url)
for our testing, it replaces the real vddk side-car container.