### PR TITLE
Lower the CPU requests for PODs in our CI

### DIFF
--- a/.github/workflows/run_forklift_build_on_kind.yml
+++ b/.github/workflows/run_forklift_build_on_kind.yml
@@ -43,6 +43,8 @@ jobs:
 
       - run: kubectl wait deployment -n konveyor-forklift forklift-controller --for condition=Available=True --timeout=180s
 
+      - run: kubectl describe nodes
+    
       - run: kubectl get pods -n konveyor-forklift
 
       - run: kubectl get providers -n konveyor-forklift -o yaml

--- a/deploy_local_forklift_bazel.sh
+++ b/deploy_local_forklift_bazel.sh
@@ -30,4 +30,7 @@ spec:
   feature_must_gather_api: false
   must_gather_api_tls_enabled: false
   ui_tls_enabled: false
+  inventory_container_requests_cpu: "200m"
+  validation_container_requests_cpu: "300m"
+  controller_container_requests_cpu: "100m" 
 EOF


### PR DESCRIPTION
GH-Actions is providing 2 Cores Only, with the default values we exceed that.

```Allocated resources:
203  (Total limits may be over 100 percent, i.e., overcommitted.)
204  Resource                       Requests      Limits
205  --------                       --------      ------
206  cpu                            1855m (92%)   1600m (80%)
207  memory                         3785Mi (54%)  2214Mi (31%)
```

Signed-off-by: Evgeny Slutsky <eslutsky@redhat.com>