### PR TITLE
Set bazel version to 5.4.0

### DIFF
--- a/build_forklift_bazel.sh
+++ b/build_forklift_bazel.sh
@@ -18,6 +18,7 @@ cd ${FORKLIFT_DIR:-forklift}
 export REGISTRY=localhost:5001
 export REGISTRY_TAG=latest
 export REGISTRY_ACCOUNT=""
+export USE_BAZEL_VERSION=5.4.0
 
 bazel run push-forklift-controller
 bazel run push-forklift-validation


### PR DESCRIPTION
We used to take the latest and when when bazel released 6.0.0 it broke us. It's better to set a specific version so we won't break in such cases.