### PR TITLE
Deploy fakeovirt and imageio simultaneously

### DIFF
--- a/ovirt/ovirt_imageio_deployment.yml
+++ b/ovirt/ovirt_imageio_deployment.yml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: imageio
+  name: ovirt-imageio
   namespace: konveyor-forklift
 spec:
   replicas: 1
@@ -25,7 +25,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: imageio
+  name: ovirt-imageio
   namespace: konveyor-forklift
 spec:
   selector:

--- a/ovirt/setup.sh
+++ b/ovirt/setup.sh
@@ -3,12 +3,12 @@
 set -ex
 
 kubectl apply -f ovirt/patch.yml
-
 kubectl apply -f ovirt/fakeovirt_deployment.yml
+kubectl apply -f ovirt/imageio_deployment.yml
+
 while ! kubectl get deployment -n konveyor-forklift fakeovirt; do sleep 10; done
 kubectl wait deployment -n konveyor-forklift fakeovirt --for condition=Available=True --timeout=180s
 
-kubectl apply -f ovirt/imageio_deployment.yml
 while ! kubectl get deployment -n konveyor-forklift imageio; do sleep 10; done
 kubectl wait deployment -n konveyor-forklift imageio --for condition=Available=True --timeout=180s
 

--- a/ovirt/setup.sh
+++ b/ovirt/setup.sh
@@ -4,12 +4,12 @@ set -ex
 
 kubectl apply -f ovirt/patch.yml
 kubectl apply -f ovirt/fakeovirt_deployment.yml
-kubectl apply -f ovirt/imageio_deployment.yml
+kubectl apply -f ovirt/ovirt_imageio_deployment.yml
 
 while ! kubectl get deployment -n konveyor-forklift fakeovirt; do sleep 10; done
 kubectl wait deployment -n konveyor-forklift fakeovirt --for condition=Available=True --timeout=180s
 
-while ! kubectl get deployment -n konveyor-forklift imageio; do sleep 10; done
-kubectl wait deployment -n konveyor-forklift imageio --for condition=Available=True --timeout=180s
+while ! kubectl get deployment -n konveyor-forklift ovirt-imageio; do sleep 10; done
+kubectl wait deployment -n konveyor-forklift ovirt-imageio --for condition=Available=True --timeout=180s
 
 . ovirt/e2e_env_vars.sh


### PR DESCRIPTION
Deploying both fakeovirt and ovirt-imageio simultaneously saves some execution time compared to deploying them sequentially.
This PR also renames `imageio` to `ovirt-imageio` in several places.