### PR TITLE
Lower requests.cpu values

### DIFF
--- a/deploy_local_forklift_bazel.sh
+++ b/deploy_local_forklift_bazel.sh
@@ -30,7 +30,7 @@ spec:
   feature_must_gather_api: false
   must_gather_api_tls_enabled: false
   ui_tls_enabled: false
-  inventory_container_requests_cpu: "200m"
-  validation_container_requests_cpu: "300m"
-  controller_container_requests_cpu: "100m" 
+  inventory_container_requests_cpu: "50m"
+  validation_container_requests_cpu: "50m"
+  controller_container_requests_cpu: "50m"
 EOF


### PR DESCRIPTION
When forkliftci runs on GitHub hosted runners, we have a limit of 2 CPUs so we need to careful with the amount of CPUs we requests for forklift controllers, otherwise the importer pod(s) may not be able to start.