### PR TITLE
Refactor fetching latest CDI version

### DIFF
--- a/k8s-deploy-kubevirt.sh
+++ b/k8s-deploy-kubevirt.sh
@@ -3,7 +3,8 @@
 set -ex
 
 # Install CDI
-export CDI_VERSION=$(curl -s https://api.github.com/repos/kubevirt/containerized-data-importer/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+LATEST_CDI=$(curl -s https://api.github.com/repos/kubevirt/containerized-data-importer/releases/latest)
+export CDI_VERSION=$(jq -r .tag_name <<< $LATEST_CDI)
 kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-operator.yaml
 kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-cr.yaml
 


### PR DESCRIPTION
We have noticed frequent failures in getting the latest version of CDI but we lack information to debug it so here we store the JSON of the latest CDI version in a variable so it would be printed and also extract the tag_name using 'jq' instead of grep+sed