### PR TITLE
Get latest CDI version using GitHub CLI

### DIFF
--- a/.github/workflows/run_forklift_build_on_kind.yml
+++ b/.github/workflows/run_forklift_build_on_kind.yml
@@ -39,7 +39,11 @@ jobs:
         run: curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
       - run: chmod u+x kubectl
 
-      - run: build_and_setup_everything_bazel.sh
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          export CDI_VERSION=$(gh api repos/kubevirt/containerized-data-importer/releases/latest | jq -r ".tag_name")
+          build_and_setup_everything_bazel.sh
 
       - run: kubectl version
 

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,10 @@ runs:
 
     - name: Build and setup everything with bazel
       shell: bash
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        export CDI_VERSION=$(gh api repos/kubevirt/containerized-data-importer/releases/latest | jq -r ".tag_name")
         cd ${{ github.action_path }}
         FORKLIFT_DIR=$GITHUB_WORKSPACE build_and_setup_everything_bazel.sh
         cd -

--- a/k8s-deploy-kubevirt.sh
+++ b/k8s-deploy-kubevirt.sh
@@ -3,8 +3,7 @@
 set -ex
 
 # Install CDI
-LATEST_CDI=$(curl -s https://api.github.com/repos/kubevirt/containerized-data-importer/releases/latest)
-export CDI_VERSION=$(jq -r .tag_name <<< $LATEST_CDI)
+[ ! -v CDI_VERSION ] && export CDI_VERSION=v1.55.2
 kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-operator.yaml
 kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-cr.yaml
 


### PR DESCRIPTION
Previously, we queried the latest version of CDI with an unauthenticated request from the command line using 'curl'. Frequently it failed with the following error:

"API rate limit exceeded ... (But here's the good news: Authenticated requests get a higer rate limit ..."

So here we change the way the latest version of CDI is queried. It is done using GitHub CLI with the access token from the GitHub repository. However, in order to keep the scripts working locally without setting an access token, there is a hard coded version that will be used when the CDI_VERSION variable is not set.

See #45