### PR TITLE
fix  running kind over remote docker

### DIFF
--- a/build_and_setup_everything_bazel_manually.sh
+++ b/build_and_setup_everything_bazel_manually.sh
@@ -7,8 +7,6 @@
 
 . ./kind_with_registry.sh
 
-[[ -z "${REMOTE_DOCKER_HOST}" ]] || { setup_kind_sshtunnel  ; trap cleanup_kind_sshtunnel ERR ;  } 
-
 ./get_forklift_bazel.sh
 
 ./k8s-deploy-kubevirt.sh

--- a/kind_with_registry.sh
+++ b/kind_with_registry.sh
@@ -2,7 +2,7 @@
 echo "Running $0"
 
 set -o errexit
-
+[ -z "${REMOTE_DOCKER_HOST}" ] || . ./setup_remote_docker_kind.sh
 
 go install sigs.k8s.io/kind@v0.15.0
 
@@ -41,6 +41,8 @@ EOF
 if [ "$(docker inspect -f='{{json .NetworkSettings.Networks.kind}}' "${reg_name}")" = 'null' ]; then
   docker network connect "kind" "${reg_name}"
 fi
+
+[ -z "${REMOTE_DOCKER_HOST}" ] || { setup_kind_sshtunnel  ; trap cleanup_kind_sshtunnel ERR ;  } 
 
 # Document the local registry
 # https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry


### PR DESCRIPTION
without this fix  kind_with_registry.sh wont be able to run correctly with remote docker

since it require kubectl we need to run setup_kind_sshtunnel before.