### PR TITLE
Minor cleanups

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,4 @@ runs:
     - name: Build and setup everything with bazel
       shell: bash
       run: |
-        cd ${{ github.action_path }}
-        FORKLIFT_DIR=$GITHUB_WORKSPACE build_and_setup_everything_bazel.sh
-        cd -
+        (cd ${{ github.action_path }}; FORKLIFT_DIR=$GITHUB_WORKSPACE build_and_setup_everything_bazel.sh)

--- a/deploy_local_forklift.sh
+++ b/deploy_local_forklift.sh
@@ -16,7 +16,7 @@ kubectl apply -f forklift-operator/forklift-k8s.yaml
 while ! kubectl get deployment -n konveyor-forklift forklift-operator; do sleep 10; done
 kubectl wait deployment -n konveyor-forklift forklift-operator --for condition=Available=True --timeout=180s
 
-cat << EOF | kubectl -n konveyor-forklift apply -f -
+cat << EOF | kubectl apply -f -
 apiVersion: forklift.konveyor.io/v1beta1
 kind: ForkliftController
 metadata:


### PR DESCRIPTION
- Drop redundant specification of namespace
- Shorten 'Build and setup everything with bazel' step