### PR TITLE
Store kubeconfig in /tmp

### DIFF
--- a/install_kind.sh
+++ b/install_kind.sh
@@ -6,6 +6,7 @@ mkdir -p /var/tmp/kind_storage
 chmod 777 /var/tmp/kind_storage
 
 kind create cluster --config kind-config.yaml
+kind get kubeconfig > /tmp/kubeconfig
 
 kubectl apply -f add_pv.yml
 

--- a/kind_with_registry.sh
+++ b/kind_with_registry.sh
@@ -37,6 +37,8 @@ containerdConfigPatches:
     endpoint = ["http://${reg_name}:5000"]
 EOF
 
+kind get kubeconfig > /tmp/kubeconfig
+
 # connect the registry to the cluster network if not already connected
 if [ "$(docker inspect -f='{{json .NetworkSettings.Networks.kind}}' "${reg_name}")" = 'null' ]; then
   docker network connect "kind" "${reg_name}"


### PR DESCRIPTION
It was stored there by the action in github.com/kubev2v/forklift but that makes it a bit more complex for ones that want to execute the tests as forkliftci does locally, so from now on forkliftci would place it in /tmp instead of relying on doing it elsewhere.