### PR TITLE
introduce nfs server to the CI 

### DIFF
--- a/build_and_setup_everything_bazel.sh
+++ b/build_and_setup_everything_bazel.sh
@@ -2,6 +2,8 @@
 
 . ./kind_with_registry.sh
 
+./install_nfs.sh
+
 ./k8s-deploy-kubevirt.sh
 
 ./k8s-deploy-cert-manager.sh

--- a/build_forklift_bazel.sh
+++ b/build_forklift_bazel.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 echo "Running $0"
 
-set -e
-
+set -ex
 SCRIPT_PATH=`realpath "$0"`
 SCRIPT_DIR=`dirname "$SCRIPT_PATH"`
 

--- a/install_nfs.sh
+++ b/install_nfs.sh
@@ -1,0 +1,21 @@
+ #!/bin/bash
+
+if [  -n "$(uname -a | grep Ubuntu)" ]; then
+    sudo apt install nfs-kernel-server -y   
+else
+    sudo dnf install nfs-utils -y
+fi  
+
+sudo mkdir -p /home/nfsshare
+sudo chown -R nobody:nogroup /home/nfsshare
+sudo chmod 777 /home/nfsshare
+sudo bash -c 'echo "/home/nfsshare  *(insecure,rw,no_root_squash)" >>/etc/exports'
+sudo exportfs -a
+
+if [  -n "$(uname -a | grep Ubuntu)" ]; then
+    sudo systemctl restart nfs-kernel-server
+else
+    sudo systemctl restart nfs-server
+fi  
+
+


### PR DESCRIPTION
nfs-server is required for the following components:
- openstack-volume-populator (with csi-driver-nfs) - WIP
- openstack test environment: packstack cinder - #59 