### PR TITLE
disable kind LegacyServiceAccountTokenNoAutoGeneration on K8s>1.24 

### DIFF
--- a/cluster/kind/kind_with_registry.sh
+++ b/cluster/kind/kind_with_registry.sh
@@ -31,6 +31,8 @@ nodes:
   extraMounts:
     - hostPath: /var/tmp/kind_storage
       containerPath: /data
+featureGates:
+  LegacyServiceAccountTokenNoAutoGeneration: false      
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]


### PR DESCRIPTION
follow-up for https://github.com/kubev2v/forkliftci/pull/21

