### PR TITLE
separate provider installation script 

### DIFF
--- a/build_and_setup_everything_bazel.sh
+++ b/build_and_setup_everything_bazel.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source ./cluster/common.sh
 
 # if none is provided set to all by default
 [ ! -z "${PROVIDER_NAME}" ] || PROVIDER_NAME="all"
@@ -24,54 +25,8 @@ echo "::endgroup::"
 
 echo "::group::${PROVIDER_NAME} setup"
 
-source ./cluster/common.sh 
+./cluster/providers/install-provider.sh "${PROVIDER_NAME}"
 
-case $PROVIDER_NAME in
-
-  "all")
-    echo "installing all providers"
-    # apply k8s volume populator manifests
-    k8s_apply_volume_populator    
-    ./cluster/providers/vmware/setup.sh
-    ./cluster/providers/ovirt/setup.sh
-    ./cluster/providers/openstack/install_nfs.sh
-    ./cluster/providers/openstack/setup.sh
-    ./cluster/providers/openstack/create_test_vms.sh
-
-    ;;
-  "vsphere")
-    echo "installing vsphere providers"
-    ./cluster/providers/vmware/setup.sh
-    ;;
-  "ovirt")
-    echo "installing ovirt providers"
-    # apply k8s volume populator manifests
-    k8s_apply_volume_populator
-
-    # installs NFS for CSI
-    ./cluster/providers/openstack/install_nfs.sh
-    ./cluster/providers/ovirt/setup.sh
-
-    ;;  
-  "openstack")
-    echo "installing openstack providers" 
-    # apply k8s volume populator manifests
-    k8s_apply_volume_populator
-      
-    #installs nfs for CSI and opentack volumes
-    ./cluster/providers/openstack/install_nfs.sh
-
-    #create openstack - packstack deployment
-    ./cluster/providers/openstack/setup.sh
-
-    #create sample VMs and volume disks for the tests
-    ./cluster/providers/openstack/create_test_vms.sh
-    ;;
-  *) 
-    echo "provider ${PROVIDER_NAME} set incorrectly"
-    exit 5
-    ;;
-esac
 echo "::endgroup::"
 
 # grant admin rights so its token can be used to access the API

--- a/build_and_setup_everything_bazel_manually.sh
+++ b/build_and_setup_everything_bazel_manually.sh
@@ -26,20 +26,14 @@ source ./cluster/common.sh
 # deploy forklift from local docker registry
 ./cluster/deploy_local_forklift_bazel.sh
 
-# run VMware provider setup
-./cluster/providers/vmware/setup.sh
-
-# run ovirt provider setup
-./cluster/providers/ovirt/setup.sh
-
-# run openstack/packstack provider setup
-./cluster/providers/openstack/setup.sh
-
 # grant admin rights so its token can be used to access the API
 k8s_grant_permissions
 
 # patch StorageProfile with ReadWriteOnce Access
 k8s_patch_storage_profile
+
+# optionally install provider (options: all/ovirt/openstack/vsphere)
+[[ -z "${PROVIDER_NAME}" ]] || ./cluster/providers/install-provider.sh "${PROVIDER_NAME}"
 
 
 echo "CLUSTER=$CLUSTER"

--- a/cluster/providers/install-provider.sh
+++ b/cluster/providers/install-provider.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -e
+
+PROVIDER_NAME=$1
+
+
+SCRIPT_PATH=`realpath "$0"`
+SCRIPT_DIR=`dirname "$SCRIPT_PATH"`
+
+source ${SCRIPT_DIR}/../common.sh
+
+case $PROVIDER_NAME in
+
+  "all")
+    echo "installing all providers"
+    # apply k8s volume populator manifests
+    k8s_apply_volume_populator    
+    ${SCRIPT_DIR}/vmware/setup.sh
+    ${SCRIPT_DIR}/ovirt/setup.sh
+    ${SCRIPT_DIR}/openstack/install_nfs.sh
+    ${SCRIPT_DIR}/openstack/setup.sh
+    ${SCRIPT_DIR}/openstack/create_test_vms.sh
+
+    ;;
+  "vsphere")
+    echo "installing vsphere providers"
+    ${SCRIPT_DIR}/vmware/setup.sh
+    ;;
+  "ovirt")
+    echo "installing ovirt providers"
+    # apply k8s volume populator manifests
+    k8s_apply_volume_populator
+
+    # installs NFS for CSI
+    ${SCRIPT_DIR}/openstack/install_nfs.sh
+    ${SCRIPT_DIR}/ovirt/setup.sh
+
+    ;;  
+  "openstack")
+    echo "installing openstack providers" 
+    # apply k8s volume populator manifests
+    k8s_apply_volume_populator
+      
+    #installs nfs for CSI and opentack volumes
+    ${SCRIPT_DIR}/openstack/install_nfs.sh
+
+    #create openstack - packstack deployment
+    ${SCRIPT_DIR}/openstack/setup.sh
+
+    #create sample VMs and volume disks for the tests
+    ${SCRIPT_DIR}/openstack/create_test_vms.sh
+    ;;
+  *) 
+    echo "provider ${PROVIDER_NAME} set incorrectly"
+    exit 5
+    ;;
+esac
+echo "::endgroup::"


### PR DESCRIPTION
this change alters the behavior when  CI installed manually (`build_and_setup_everything_bazel_manually.sh`):
- by default dont install any providers
- if ENV `PROVIDER_NAME` is set  then install  the provider  (all/ovirt/openstack/vsphere)
- optionally a provider can be installed separately by running 
`cluster/providers/install-provider.sh <all/ovirt/openstack/vsphere>`