### PR TITLE
Add permissions to NFS directories

### DIFF
--- a/cluster/providers/utils/deploy_csi_driver_nfs.sh
+++ b/cluster/providers/utils/deploy_csi_driver_nfs.sh
@@ -20,7 +20,8 @@ provisioner: nfs.csi.k8s.io
 parameters:
   server: ${nfs_server_ip}
   share: ${nfs_share}
-  subDir: nfs-csi/\${pvc.metadata.namespace}/\${pvc.metadata.name}  
+  subDir: nfs-csi/\${pvc.metadata.namespace}/\${pvc.metadata.name}
+  mountPermissions: "0777"
   # csi.storage.k8s.io/provisioner-secret is only needed for providing mountOptions in DeleteVolume
   csi.storage.k8s.io/provisioner-secret-name: "mount-options"
   csi.storage.k8s.io/provisioner-secret-namespace: "default"


### PR DESCRIPTION
In NFS-CSI 4.2.0, the permission changed to '0'. This breaks our CI as it expect the previous '0777'.