### PR TITLE
add keystone secure ssl service on port 5001

### DIFF
--- a/build_and_setup_everything_bazel.sh
+++ b/build_and_setup_everything_bazel.sh
@@ -4,11 +4,16 @@ source ./cluster/common.sh
 # if none is provided set to all by default
 [ ! -z "${PROVIDER_NAME}" ] || PROVIDER_NAME="all"
 
+# if no keystone_ssl env is provided set to true by default
+[ ! -z "${KEYSTONE_USE_SSL}" ] || KEYSTONE_USE_SSL=true
+
 # When running from the CI: find the runner IP Address will be used as NFS server.
 export NFS_IP_ADDRESS=$(ip route get 8.8.8.8 | awk '{ print $7 }' | head -1)
 # set NFS_SHARE for CI
 export NFS_SHARE="/home/nfsshare"
 export INSTALL_NFS=true
+export KEYSTONE_USE_SSL
+
 
 echo "::group::kind_installation"
 . ./cluster/kind/kind_with_registry.sh

--- a/cluster/providers/openstack/manifests/packstack_deployment.yml
+++ b/cluster/providers/openstack/manifests/packstack_deployment.yml
@@ -25,6 +25,7 @@ spec:
               - ALL
         ports:
         - containerPort: 5000
+        - containerPort: 5001        
         - containerPort: 8774        
         - containerPort: 8775
         - containerPort: 8778
@@ -64,6 +65,9 @@ spec:
     app: packstack
   type: NodePort
   ports:
+  - name: keystone-api-ssl
+    port: 5001
+    nodePort: 30051  
   - name: keystone-api
     port: 5000
     nodePort: 30050

--- a/cluster/providers/openstack/setup.sh
+++ b/cluster/providers/openstack/setup.sh
@@ -20,3 +20,7 @@ run_command_deployment packstack_update_endpoints
 run_command_deployment packstack_patch_snapshots_support
 run_command_deployment packstack_update_nfs_path  "${NFS_IP_ADDRESS}:${NFS_SHARE}"
 run_command_deployment healthcheck
+
+# add keystone SSL on port 5001
+[ -z "${KEYSTONE_USE_SSL}" ] || run_command_deployment create_certs
+[ -z "${KEYSTONE_USE_SSL}" ] || run_command_deployment add_apache_keystone_ssl


### PR DESCRIPTION
packstack installation doesn't support built-in SSL/keystone deployment , so we add it at as Apache configuration .

internally all the openstack components  communicate with keystone on http/5000 , we add additional secure keystone on https/5001 - for external authentication