### PR TITLE
expose packstack keystone port in kind

### DIFF
--- a/cluster/kind/kind_with_registry.sh
+++ b/cluster/kind/kind_with_registry.sh
@@ -32,6 +32,9 @@ nodes:
   extraMounts:
     - hostPath: /var/tmp/kind_storage
       containerPath: /data
+  extraPortMappings:
+    - containerPort: 30050
+      hostPort: 30050
 featureGates:
   LegacyServiceAccountTokenNoAutoGeneration: false      
 containerdConfigPatches:


### PR DESCRIPTION
enable outside connection to the keystone  nodeport, so we could  connect to it from outside of the cluster.