### PR TITLE
removes version pin from HCO subscription

### DIFF
--- a/cluster/okd-on-ovirt/utils.sh
+++ b/cluster/okd-on-ovirt/utils.sh
@@ -184,7 +184,6 @@ spec:
   sourceNamespace: openshift-marketplace
   name: community-kubevirt-hyperconverged
   channel: "stable" 
-  startingCSV: kubevirt-hyperconverged-operator.v1.8.1
   installPlanApproval: Automatic
 EOF
 


### PR DESCRIPTION
when a new HCO Z-stream released previous stops working. with error: `Failed to pull image`,
so we always get the latest from the `stable` channel.
