### PR TITLE
Make a "valid" VDDK init image

### DIFF
--- a/stub-images/vddk-test-vmdk/BUILD.bazel
+++ b/stub-images/vddk-test-vmdk/BUILD.bazel
@@ -23,7 +23,7 @@ container_run_and_extract(
 
 container_image(
     name = "vddk-test-image",
-    entrypoint = "mkdir -p /opt/testing && cp -f /libvddk-test-plugin.so /opt/testing/libvddk-test-plugin.so && cp -f /cirros.vmdk /opt/testing/nbdtest.img",
+    entrypoint = "mkdir -p /opt/testing && cp -f /libvddk-test-plugin.so /opt/testing/libvddk-test-plugin.so && cp -f /cirros.vmdk /opt/testing/nbdtest.img && mkdir -p /opt/vmware-vix-disklib-distrib/lib64/ && touch /opt/vmware-vix-disklib-distrib/lib64/libvixDiskLib.so",
     files = [
         ":vddk-test-plugin",
         "convert_to_vmdk/tmp/cirros.vmdk",


### PR DESCRIPTION
forklift-controller is about to check the validity of the VDDK image by existence of opt/vmware-vix-disklib-distrib/lib64/libvixDiskLib.so and therefore the stub image of VDDK that is used in our tests needs to have it.