### PR TITLE
Use a specific version of docker.io/vmware/vcsim so the CI won't break.

### DIFF
--- a/cluster/providers/vmware/vcsim_deployment.yml
+++ b/cluster/providers/vmware/vcsim_deployment.yml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: vcsim
         command: ["/vcsim", "-l", "0.0.0.0:8989", "-tlscert", "/etc/secret/tls.crt", "-tlskey", "/etc/secret/tls.key"]
-        image: docker.io/vmware/vcsim:latest
+        image: docker.io/vmware/vcsim:v0.37.3
         ports:
         - containerPort: 8989
         volumeMounts:

--- a/cluster/providers/vmware/vcsim_deployment.yml.debug
+++ b/cluster/providers/vmware/vcsim_deployment.yml.debug
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: vcsim
-        image: docker.io/vmware/vcsim:latest
+        image: docker.io/vmware/vcsim:v0.37.3
         ports:
         - containerPort: 8989
       - name: govc


### PR DESCRIPTION
Recently, a new tag was added to docker.io/vmware/vcsim, which caused one of the vSphere tests to fail. This change uses the previous tag instead of the latest and ensures the CI remains stable regardless of new changes.